### PR TITLE
Add default logging configuration

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -3,3 +3,6 @@ frontend=*,80;healthmon;no-tls
 frontend=127.0.0.1,3001;api;no-tls
 # health check
 frontend=127.0.0.1,8080;healthmon;no-tls
+# errorlog
+accesslog-file=/var/log/nghttpx/access.log
+errorlog-file=/var/log/nghttpx/error.log


### PR DESCRIPTION
Add logging options to default configuration because we don't want to write them to pod log.
Access log may be interesting since we might want to see which requires are rejected in this phase.
