### PR TITLE
More port bakend config

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,9 @@ is the JSON dictionary, and can contain the following key value pairs:
 * `sni`: Specify SNI hostname for TLS connection.  This is used to
   validate server certificate.
 
+* `dns`: Specify whether backend host name should be resolved
+  dynamically.
+
 The following example specifies HTTP/2 as backend connection for
 service "greeter", and service port "50051":
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ is the JSON dictionary, and can contain the following key value pairs:
 * `dns`: Specify whether backend host name should be resolved
   dynamically.
 
+* `affinity`: Specify session affinity method.  Specifying `ip`
+  enables client IP based session affinity.  Specifying `none` or
+  omitting this key disables session affinity.
+
 The following example specifies HTTP/2 as backend connection for
 service "greeter", and service port "50051":
 

--- a/nghttpx-backend.tmpl
+++ b/nghttpx-backend.tmpl
@@ -1,6 +1,6 @@
 {{ range $upstream := .upstreams -}}
 # {{ $upstream.Name }}
 {{ range $backend := $upstream.Backends -}}
-backend={{ $backend.Address }},{{ $backend.Port }};{{ $upstream.Host }}{{ $upstream.Path }};proto={{ $backend.Protocol }}{{ if $backend.TLS }};tls{{ end }}{{ if $backend.SNI }};sni={{ $backend.SNI }}{{ end }}
+backend={{ $backend.Address }},{{ $backend.Port }};{{ $upstream.Host }}{{ $upstream.Path }};proto={{ $backend.Protocol }}{{ if $backend.TLS }};tls{{ end }}{{ if $backend.SNI }};sni={{ $backend.SNI }}{{ end }}{{ if $backend.DNS }};dns{{ end }}
 {{ end -}}
 {{ end }}

--- a/nghttpx-backend.tmpl
+++ b/nghttpx-backend.tmpl
@@ -1,6 +1,6 @@
 {{ range $upstream := .upstreams -}}
 # {{ $upstream.Name }}
 {{ range $backend := $upstream.Backends -}}
-backend={{ $backend.Address }},{{ $backend.Port }};{{ $upstream.Host }}{{ $upstream.Path }};proto={{ $backend.Protocol }}{{ if $backend.TLS }};tls{{ end }}{{ if $backend.SNI }};sni={{ $backend.SNI }}{{ end }}{{ if $backend.DNS }};dns{{ end }}
+backend={{ $backend.Address }},{{ $backend.Port }};{{ $upstream.Host }}{{ $upstream.Path }};proto={{ $backend.Protocol }}{{ if $backend.TLS }};tls{{ end }}{{ if $backend.SNI }};sni={{ $backend.SNI }}{{ end }}{{ if $backend.DNS }};dns{{ end }}{{ if $backend.Affinity }};affinity={{ $backend.Affinity }}{{ end }}
 {{ end -}}
 {{ end }}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -933,6 +933,7 @@ func (lbc *LoadBalancerController) getEndpoints(s *api.Service, servicePort ints
 					Protocol: portBackendConfig.Proto,
 					TLS:      portBackendConfig.TLS,
 					SNI:      portBackendConfig.SNI,
+					DNS:      portBackendConfig.DNS,
 				}
 				upsServers = append(upsServers, ups)
 			}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -728,13 +728,7 @@ func (lbc *LoadBalancerController) getUpstreamServers(data []interface{}) ([]*ng
 					if strconv.Itoa(int(servicePort.Port)) == bp || servicePort.TargetPort.String() == bp || servicePort.Name == bp {
 						portBackendConfig, ok := svcBackendConfig[bp]
 						if ok {
-							glog.Infof("use port backend configuration for service %v: %+v", svcKey, svcBackendConfig)
-							switch portBackendConfig.Proto {
-							case "h2", "http/1.1":
-							default:
-								glog.Errorf("unrecognized backend protocol %v for service %v, port %v", portBackendConfig.Proto, svcKey, bp)
-								portBackendConfig.Proto = "http/1.1"
-							}
+							portBackendConfig = fixupBackendConfig(portBackendConfig, svcKey, bp)
 						} else {
 							portBackendConfig = defaultPortBackendConfig()
 						}
@@ -934,6 +928,7 @@ func (lbc *LoadBalancerController) getEndpoints(s *api.Service, servicePort ints
 					TLS:      portBackendConfig.TLS,
 					SNI:      portBackendConfig.SNI,
 					DNS:      portBackendConfig.DNS,
+					Affinity: portBackendConfig.Affinity,
 				}
 				upsServers = append(upsServers, ups)
 			}

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -36,6 +36,8 @@ import (
 	"k8s.io/kubernetes/pkg/client/cache"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/util/wait"
+
+	"github.com/zlabjp/nghttpx-ingress-lb/pkg/nghttpx"
 )
 
 // StoreToIngressLister makes a Store that lists Ingress.
@@ -173,4 +175,24 @@ func waitForPodCondition(clientset internalclientset.Interface, ns, podName stri
 
 		return false, nil
 	})
+}
+
+// fixupBackendConfig validates config, and fixes the invalid values inside it.  svc and port is service name and port that config is
+// associated to.
+func fixupBackendConfig(config nghttpx.PortBackendConfig, svc, port string) nghttpx.PortBackendConfig {
+	glog.Infof("use port backend configuration for service %v: %+v", svc, config)
+	switch config.Proto {
+	case "h2", "http/1.1":
+	default:
+		glog.Errorf("unrecognized backend protocol %v for service %v, port %v", config.Proto, svc, port)
+		config.Proto = "http/1.1"
+	}
+	switch config.Affinity {
+	case "", nghttpx.AffinityNone, nghttpx.AffinityIP:
+		// OK
+	default:
+		glog.Errorf("unsupported affinity method %v for service %v, port %v", config.Affinity, svc, port)
+		config.Affinity = ""
+	}
+	return config
 }

--- a/pkg/nghttpx/types.go
+++ b/pkg/nghttpx/types.go
@@ -53,6 +53,7 @@ type UpstreamServer struct {
 	Protocol string
 	TLS      bool
 	SNI      string
+	DNS      bool
 }
 
 // UpstreamServerByAddrPort sorts upstream servers by address and port
@@ -109,4 +110,6 @@ type PortBackendConfig struct {
 	TLS bool `json:"tls,omitempty"`
 	// SNI hostname for backend TLS connection
 	SNI string `json:"sni,omitempty"`
+	// DNS is true if backend hostname is resolved dynamically rather than start up or configuration reloading.
+	DNS bool `json:"dns,omitempty"`
 }

--- a/pkg/nghttpx/types.go
+++ b/pkg/nghttpx/types.go
@@ -46,6 +46,13 @@ func (c UpstreamByNameServers) Less(i, j int) bool {
 	return c[i].Name < c[j].Name
 }
 
+type Affinity string
+
+const (
+	AffinityNone = "none"
+	AffinityIP   = "ip"
+)
+
 // UpstreamServer describes a server in an nghttpx upstream
 type UpstreamServer struct {
 	Address  string
@@ -54,6 +61,7 @@ type UpstreamServer struct {
 	TLS      bool
 	SNI      string
 	DNS      bool
+	Affinity Affinity
 }
 
 // UpstreamServerByAddrPort sorts upstream servers by address and port
@@ -112,4 +120,6 @@ type PortBackendConfig struct {
 	SNI string `json:"sni,omitempty"`
 	// DNS is true if backend hostname is resolved dynamically rather than start up or configuration reloading.
 	DNS bool `json:"dns,omitempty"`
+	// Affinity is session affinity method nghttpx supports.  See affinity parameter in backend option of nghttpx.
+	Affinity Affinity `json:"affinity,omitempty"`
 }


### PR DESCRIPTION
Fixes #17 

Note that dns parameter might not work without upgrading nghttpx to v1.18.1.