### PR TITLE
Gracefully shut down nghttpx

### DIFF
--- a/pkg/cmd/main.go
+++ b/pkg/cmd/main.go
@@ -153,9 +153,10 @@ func main() {
 
 	lbc.Run()
 
-	for {
-		glog.Infof("Waiting for pod deletion...")
-		time.Sleep(30 * time.Second)
+	glog.Infof("Waiting for nghttpx to shut down...")
+	select {
+	case <-lbc.Nghttpx().DoneCh:
+		glog.Infof("Done")
 	}
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -996,7 +996,7 @@ func (lbc *LoadBalancerController) removeFromIngress(ings []interface{}) {
 // Run starts the loadbalancer controller.
 func (lbc *LoadBalancerController) Run() {
 	glog.Infof("Starting nghttpx loadbalancer controller")
-	go lbc.nghttpx.Start()
+	go lbc.nghttpx.Start(lbc.stopCh)
 
 	go lbc.ingController.Run(lbc.stopCh)
 	go lbc.endpController.Run(lbc.stopCh)

--- a/pkg/nghttpx/main.go
+++ b/pkg/nghttpx/main.go
@@ -55,6 +55,8 @@ type Manager struct {
 	ConfigFile string
 	// nghttpx backend configuration file path
 	BackendConfigFile string
+	// DoneCh signals when nghttpx finishes
+	DoneCh chan struct{}
 
 	reloadRateLimiter flowcontrol.RateLimiter
 
@@ -88,6 +90,7 @@ func NewManager() *Manager {
 		BackendConfigFile: "/etc/nghttpx/nghttpx-backend.conf",
 		reloadLock:        &sync.Mutex{},
 		reloadRateLimiter: flowcontrol.NewTokenBucketRateLimiter(0.1, 1),
+		DoneCh:            make(chan struct{}),
 	}
 
 	ngx.createCertsDir(tlsDirectory)


### PR DESCRIPTION
When controller gets SIGTERM signal, SIQUIT signal is sent to nghttpx
master process to make it shut down gracefully.  Controller now exits
when nghttpx finishes without waiting for pod deletion