### PR TITLE
Use single sync key, and apply throttling on sync function

### DIFF
--- a/pkg/nghttpx/command.go
+++ b/pkg/nghttpx/command.go
@@ -73,8 +73,6 @@ func (ngx *Manager) Start(stopCh <-chan struct{}) {
 // nghttpx is going to shutdown gracefully.  The invocation of new
 // process may fail due to invalid configurations.
 func (ngx *Manager) CheckAndReload(cfg NghttpxConfiguration, ingressCfg IngressConfig) (bool, error) {
-	ngx.reloadRateLimiter.Accept()
-
 	ngx.reloadLock.Lock()
 	defer ngx.reloadLock.Unlock()
 

--- a/pkg/nghttpx/main.go
+++ b/pkg/nghttpx/main.go
@@ -33,8 +33,6 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-
-	"k8s.io/kubernetes/pkg/util/flowcontrol"
 )
 
 var (
@@ -59,8 +57,6 @@ type Manager struct {
 	BackendConfigFile string
 	// httpClient is used to issue backend API request to nghttpx
 	httpClient *http.Client
-
-	reloadRateLimiter flowcontrol.RateLimiter
 
 	// template loaded ready to be used to generate the nghttpx configuration file
 	template *template.Template
@@ -91,7 +87,6 @@ func NewManager() *Manager {
 		ConfigFile:        "/etc/nghttpx/nghttpx.conf",
 		BackendConfigFile: "/etc/nghttpx/nghttpx-backend.conf",
 		reloadLock:        &sync.Mutex{},
-		reloadRateLimiter: flowcontrol.NewTokenBucketRateLimiter(0.1, 1),
 		httpClient: &http.Client{
 			Timeout: time.Second * 30,
 		},


### PR DESCRIPTION
Previously, we apply throttling on CheckAndReload function.  It means
that we most likely use older configuration.  In this commit, we apply
throttling on sync function, and use latest configuration if possible.

Since the controller always uses all available information, it is not
necessary to enqueue the object key which has some events.  Therefore,
we use the same key for all events.

Fixes #26 