### PR TITLE
Redirect to https URI if Ingress contains TLS, and service is accessed via cleartext HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ spec:
     servicePort: 80
 ```
 
+If TLS is configured for a service, and it is accessed via cleartext
+HTTP, those requests are redirected to https URI.  If
+--default-tls-secret flag is used, all cleartext HTTP requests are
+redirected to https URI.
+
 ## Logs
 
 The access and error log of nghttpx are written to
@@ -227,7 +232,7 @@ I1226 09:31:32.305093       1 command.go:78] change in configuration detected. R
 
 - When no TLS is configured, ingress controller still listen on port 443 for cleartext HTTP.
 - TLS configuration is not bound to the specific service.  In general,
-  all proxied services are accessible via both TLS and cleartext HTTP.
+  all proxied services are accessible via TLS.
 - Ingress allows regular expression in
   `.spec.rules[*].http.paths[*].path`, but nghttpx does not support it.
 

--- a/nghttpx-backend.tmpl
+++ b/nghttpx-backend.tmpl
@@ -1,6 +1,6 @@
 {{ range $upstream := .upstreams -}}
 # {{ $upstream.Name }}
 {{ range $backend := $upstream.Backends -}}
-backend={{ $backend.Address }},{{ $backend.Port }};{{ $upstream.Host }}{{ $upstream.Path }};proto={{ $backend.Protocol }}{{ if $backend.TLS }};tls{{ end }}{{ if $backend.SNI }};sni={{ $backend.SNI }}{{ end }}{{ if $backend.DNS }};dns{{ end }};affinity={{ $backend.Affinity }}
+backend={{ $backend.Address }},{{ $backend.Port }};{{ $upstream.Host }}{{ $upstream.Path }};proto={{ $backend.Protocol }}{{ if $backend.TLS }};tls{{ end }}{{ if $backend.SNI }};sni={{ $backend.SNI }}{{ end }}{{ if $backend.DNS }};dns{{ end }};affinity={{ $backend.Affinity }}{{ if $upstream.RedirectIfNotTLS }};redirect-if-not-tls{{ end}}
 {{ end -}}
 {{ end }}

--- a/pkg/cmd/main.go
+++ b/pkg/cmd/main.go
@@ -87,7 +87,7 @@ var (
                 NodeLegacyHostIP is not assigned or cannot be used.`)
 
 	defaultTLSSecret = flags.String("default-tls-secret", "",
-		`Optional, name of the Secret that contains TLS server certificate and secret key to enable TLS by default.`)
+		`Optional, name of the Secret that contains TLS server certificate and secret key to enable TLS by default.  For those client connections which are not TLS encrypted, they are redirected to https URI permantently.`)
 
 	ingressClass = flags.String("ingress-class", "nghttpx",
 		`Ingress class which this controller is responsible for.`)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -459,6 +459,10 @@ func TestSyncDefaultSecret(t *testing.T) {
 	if got, want := ingConfig.DefaultTLSCred.Cert.Checksum, nghttpx.Checksum(dCrt); got != want {
 		t.Errorf("ingConfig.DefaultTLSCred.Cert.Checksum = %v, want %v", got, want)
 	}
+
+	if got, want := ingConfig.Upstreams[0].RedirectIfNotTLS, true; got != want {
+		t.Errorf("ingConfig.RedirectIfNotTLS = %v, want %v", got, want)
+	}
 }
 
 // TestSyncDupDefaultSecret verifies that duplicated default TLS secret is removed.
@@ -497,6 +501,12 @@ func TestSyncDupDefaultSecret(t *testing.T) {
 	}
 	if got, want := len(ingConfig.SubTLSCred), 0; got != want {
 		t.Errorf("len(ingConfig.SubTLSCred) = %v, want %v", got, want)
+	}
+
+	for i, _ := range ingConfig.Upstreams {
+		if got, want := ingConfig.Upstreams[i].RedirectIfNotTLS, true; got != want {
+			t.Errorf("ingConfig.Upstreams[%v].RedirectIfNotTLS = %v, want %v", i, got, want)
+		}
 	}
 }
 

--- a/pkg/nghttpx/types.go
+++ b/pkg/nghttpx/types.go
@@ -60,10 +60,11 @@ func NewIngressConfig() *IngressConfig {
 
 // Upstream describes an nghttpx upstream
 type Upstream struct {
-	Name     string
-	Host     string
-	Path     string
-	Backends []UpstreamServer
+	Name             string
+	Host             string
+	Path             string
+	Backends         []UpstreamServer
+	RedirectIfNotTLS bool
 }
 
 // UpstreamByNameServers sorts upstreams by name


### PR DESCRIPTION
Fixes #32 