### PR TITLE
Add mruby file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,30 @@ nghttpx ingress controller, by default, overrides the following default configur
 
 User can override `workers` using ConfigMap.
 
+Since `mruby-file` option takes a path to mruby script file, user has
+to include mruby script to the image or mount the external volume.  In
+order to make it easier to specify mruby script, user can write mruby
+script under `nghttpx-mruby-file-content` key, like so:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nghttpx-ingress-lb
+data:
+  nghttpx-mruby-file-content: |
+    class App
+      def on_req(env)
+        env.req.path = "/apps#{env.req.path}"
+      end
+    end
+
+    App.new
+```
+
+The controller saves the content, and mruby-file option which refers
+to the saved file is added to the configuration.
+
 ## Troubleshooting
 
 TBD

--- a/nghttpx.tmpl
+++ b/nghttpx.tmpl
@@ -35,3 +35,8 @@ workers={{ .Workers }}
 # from ConfigMap
 
 {{ .ExtraConfig }}
+
+{{ if .MrubyFile }}
+# checksum: {{ .MrubyFile.Checksum }}
+mruby-file={{ .MrubyFile.Path }}
+{{ end }}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -384,6 +384,8 @@ func TestSyncDefaultBackend(t *testing.T) {
 
 	cm := newEmptyConfigMap()
 	cm.Data[nghttpx.NghttpxExtraConfigKey] = "Test"
+	const mrubyContent = "mruby"
+	cm.Data[nghttpx.NghttpxMrubyFileContentKey] = mrubyContent
 	svc, eps := newDefaultBackend()
 
 	f.cmStore = append(f.cmStore, cm)
@@ -421,6 +423,13 @@ func TestSyncDefaultBackend(t *testing.T) {
 
 	if got, want := fm.ingConfig.ExtraConfig, cm.Data[nghttpx.NghttpxExtraConfigKey]; got != want {
 		t.Errorf("fm.cfg.ExtraConfig = %v, want %v", got, want)
+	}
+	if got, want := fm.ingConfig.MrubyFile, (&nghttpx.ChecksumFile{
+		Path:     "/etc/nghttpx/mruby.rb",
+		Content:  []byte(mrubyContent),
+		Checksum: nghttpx.Checksum([]byte(mrubyContent)),
+	}); !reflect.DeepEqual(got, want) {
+		t.Errorf("fm.ingConfig.MrubyFile = %q, want %q", got, want)
 	}
 }
 

--- a/pkg/nghttpx/command.go
+++ b/pkg/nghttpx/command.go
@@ -114,6 +114,9 @@ func (ngx *Manager) CheckAndReload(ingressCfg *IngressConfig) (bool, error) {
 		if err := ngx.writeTLSKeyCert(ingressCfg); err != nil {
 			return false, err
 		}
+		if err := ngx.writeMrubyFile(ingressCfg); err != nil {
+			return false, err
+		}
 
 		cmd := "killall"
 		args := []string{"-HUP", "nghttpx"}
@@ -240,6 +243,20 @@ func (ngx *Manager) waitUntilConfigRevisionChanges(oldConfRev string) error {
 		}
 	}); err != nil {
 		return fmt.Errorf("Could not get new nghttpx configRevision: %v", err)
+	}
+
+	return nil
+}
+
+// writeMrubyFile writes mruby script file.  If ingConfig.MrubyFile is nil, this function does nothing, and succeeds.
+func (ngx *Manager) writeMrubyFile(ingConfig *IngressConfig) error {
+	if ingConfig.MrubyFile == nil {
+		return nil
+	}
+
+	f := ingConfig.MrubyFile
+	if err := writeFile(f.Path, f.Content); err != nil {
+		return fmt.Errorf("failed to write mruby file: %v", err)
 	}
 
 	return nil

--- a/pkg/nghttpx/types.go
+++ b/pkg/nghttpx/types.go
@@ -50,6 +50,9 @@ type IngressConfig struct {
 	Workers string
 	// ExtraConfig is the extra configurations in a format that nghttpx accepts in --conf.
 	ExtraConfig string
+	// MrubyFileContent is the extra mruby script.  It is saved in the container disk space, and will be referenced by mruby-file from
+	// configuration file.
+	MrubyFile *ChecksumFile
 }
 
 // NewIngressConfig returns new IngressConfig.  Workers is initialized as the number of CPU cores.

--- a/pkg/nghttpx/utils.go
+++ b/pkg/nghttpx/utils.go
@@ -41,11 +41,21 @@ import (
 const (
 	// NghttpxExtraConfigKey is a field name of extra nghttpx configuration in ConfigMap.
 	NghttpxExtraConfigKey = "nghttpx-conf"
+	// NghttpxMrubyFileContentKey is a field name of mruby script in ConfigMap.
+	NghttpxMrubyFileContentKey = "nghttpx-mruby-file-content"
 )
 
 // ReadConfig obtains the configuration defined by the user merged with the defaults.
 func ReadConfig(ingConfig *IngressConfig, config *api.ConfigMap) {
 	ingConfig.ExtraConfig = config.Data[NghttpxExtraConfigKey]
+	if mrubyFileContent, ok := config.Data[NghttpxMrubyFileContentKey]; ok {
+		b := []byte(mrubyFileContent)
+		ingConfig.MrubyFile = &ChecksumFile{
+			Path:     "/etc/nghttpx/mruby.rb",
+			Content:  b,
+			Checksum: Checksum(b),
+		}
+	}
 }
 
 // needsReload first checks that configuration is changed.  filename


### PR DESCRIPTION
The controller looks for nghttpx-mruby-file-content key in ConfigMap.
Its associated string is used as a mruby script, and it is referenced
by mruby-file option from the configuration file.

Fixes #29 