### PR TITLE
Add flags to run nghttpx contorller outside cluster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,6 @@ RUN apt-get update && apt-get install -y git g++ make binutils autoconf automake
     apt-get clean
 
 RUN mkdir -p /var/log/nghttpx
-RUN mkdir -p /etc/nghttpx
-RUN touch /etc/nghttpx/nghttpx-backend.conf
 
 COPY nghttpx-ingress-controller /
 COPY nghttpx.tmpl /

--- a/nghttpx.tmpl
+++ b/nghttpx.tmpl
@@ -1,14 +1,14 @@
 accesslog-file=/dev/stdout
 
-include=/etc/nghttpx/nghttpx-backend.conf
+include={{ .ConfDir }}/nghttpx-backend.conf
 
-frontend=*,80;no-tls
+frontend=*,{{ .HTTPPort }};no-tls
 
 # API endpoints
 frontend=127.0.0.1,{{ .APIPort }};api;no-tls
 
 {{ if .TLS }}
-frontend=*,443
+frontend=*,{{ .HTTPSPort }}
 
 {{ $defaultCred := .DefaultTLSCred }}
 # checksum is required to detect changes in the generated configuration and force a reload
@@ -22,8 +22,8 @@ subcert={{ $cred.Key.Path }}:{{ $cred.Cert.Path }}
 {{ end }}
 
 {{ else }}
-# just listen 443 to gain port 443, so that we can always bind that address.
-frontend=*,443;no-tls
+# just listen {{ .HTTPSPort }} to gain port {{ .HTTPSPort }}, so that we can always bind that address.
+frontend=*,{{ .HTTPSPort }};no-tls
 {{ end }}
 
 # for health check

--- a/pkg/nghttpx/main.go
+++ b/pkg/nghttpx/main.go
@@ -27,16 +27,8 @@ package nghttpx
 import (
 	"fmt"
 	"net/http"
-	"os"
 	"text/template"
 	"time"
-
-	"github.com/golang/glog"
-)
-
-var (
-	// Base directory that contains the mounted secrets with TLS certificates, keys and
-	tlsDirectory = "/etc/nghttpx-tls"
 )
 
 // Manager ...
@@ -59,13 +51,6 @@ type Manager struct {
 	configrevisionURI string
 }
 
-const (
-	// nghttpx main configuration file path
-	ConfigFile = "/etc/nghttpx/nghttpx.conf"
-	// nghttpx backend configuration file path
-	BackendConfigFile = "/etc/nghttpx/nghttpx-backend.conf"
-)
-
 // NewManager ...
 func NewManager(apiPort int) *Manager {
 	ngx := &Manager{
@@ -80,19 +65,7 @@ func NewManager(apiPort int) *Manager {
 		configrevisionURI: fmt.Sprintf("http://127.0.0.1:%v/api/v1beta1/configrevision", apiPort),
 	}
 
-	ngx.createCertsDir(tlsDirectory)
-
 	ngx.loadTemplate()
 
 	return ngx
-}
-
-func (nghttpx *Manager) createCertsDir(base string) {
-	if err := os.Mkdir(base, os.ModeDir); err != nil {
-		if os.IsExist(err) {
-			glog.Infof("%v already exists", err)
-			return
-		}
-		glog.Fatalf("Couldn't create directory %v: %v", base, err)
-	}
 }

--- a/pkg/nghttpx/tls_test.go
+++ b/pkg/nghttpx/tls_test.go
@@ -33,6 +33,10 @@ import (
 	"time"
 )
 
+const (
+	defaultConfDir = "dir"
+)
+
 func TestCreateTLSCred(t *testing.T) {
 	// openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /tmp/tls.key -out /tmp/tls.crt -subj "/CN=echoheaders/O=echoheaders"
 	tlsCrt := "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURhakNDQWxLZ0F3SUJBZ0lKQUxHUXR5VVBKTFhYTUEwR0NTcUdTSWIzRFFFQkJRVUFNQ3d4RkRBU0JnTlYKQkFNVEMyVmphRzlvWldGa1pYSnpNUlF3RWdZRFZRUUtFd3RsWTJodmFHVmhaR1Z5Y3pBZUZ3MHhOakF6TXpFeQpNekU1TkRoYUZ3MHhOekF6TXpFeU16RTVORGhhTUN3eEZEQVNCZ05WQkFNVEMyVmphRzlvWldGa1pYSnpNUlF3CkVnWURWUVFLRXd0bFkyaHZhR1ZoWkdWeWN6Q0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0MKZ2dFQkFONzVmS0N5RWwxanFpMjUxTlNabDYzeGQweG5HMHZTVjdYL0xxTHJveVNraW5nbnI0NDZZWlE4UEJWOAo5TUZzdW5RRGt1QVoyZzA3NHM1YWhLSm9BRGJOMzhld053RXNsVDJkRzhRTUw0TktrTUNxL1hWbzRQMDFlWG1PCmkxR2txZFA1ZUExUHlPZCtHM3gzZmxPN2xOdmtJdHVHYXFyc0tvMEhtMHhqTDVtRUpwWUlOa0tGSVhsWWVLZS8KeHRDR25CU2tLVHFMTG0yeExKSGFFcnJpaDZRdkx4NXF5U2gzZTU2QVpEcTlkTERvcWdmVHV3Z2IzekhQekc2NwppZ0E0dkYrc2FRNHpZUE1NMHQyU1NiVkx1M2pScWNvL3lxZysrOVJBTTV4bjRubnorL0hUWFhHKzZ0RDBaeGI1CmVVRDNQakVhTnlXaUV2dTN6UFJmdysyNURMY0NBd0VBQWFPQmpqQ0JpekFkQmdOVkhRNEVGZ1FVcktMZFhHeUUKNUlEOGRvd2lZNkdzK3dNMHFKc3dYQVlEVlIwakJGVXdVNEFVcktMZFhHeUU1SUQ4ZG93aVk2R3Mrd00wcUp1aApNS1F1TUN3eEZEQVNCZ05WQkFNVEMyVmphRzlvWldGa1pYSnpNUlF3RWdZRFZRUUtFd3RsWTJodmFHVmhaR1Z5CmM0SUpBTEdRdHlVUEpMWFhNQXdHQTFVZEV3UUZNQU1CQWY4d0RRWUpLb1pJaHZjTkFRRUZCUUFEZ2dFQkFNZVMKMHFia3VZa3Z1enlSWmtBeE1PdUFaSDJCK0Evb3N4ODhFRHB1ckV0ZWN5RXVxdnRvMmpCSVdCZ2RkR3VBYU5jVQorUUZDRm9NakJOUDVWVUxIWVhTQ3VaczN2Y25WRDU4N3NHNlBaLzhzbXJuYUhTUjg1ZVpZVS80bmFyNUErdWErClIvMHJrSkZnOTlQSmNJd3JmcWlYOHdRcWdJVVlLNE9nWEJZcUJRL0VZS2YvdXl6UFN3UVZYRnVJTTZTeDBXcTYKTUNML3d2RlhLS0FaWDBqb3J4cHRjcldkUXNCcmYzWVRnYmx4TE1sN20zL2VuR1drcEhDUHdYeVRCOC9rRkw3SApLL2ZHTU1NWGswUkVSbGFPM1hTSUhrZUQ2SXJiRnRNV3R1RlJwZms2ZFA2TXlMOHRmTmZ6a3VvUHVEWUFaWllWCnR1NnZ0c0FRS0xWb0pGaGV0b1k9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
@@ -50,15 +54,15 @@ func TestCreateTLSCred(t *testing.T) {
 	}
 
 	name := fmt.Sprintf("test-%v", time.Now().UnixNano())
-	tlsCred, err := CreateTLSCred(name, dCrt, dKey)
+	tlsCred, err := CreateTLSCred(defaultConfDir, name, dCrt, dKey)
 	if err != nil {
 		t.Fatalf("unexpected error writing TLS key pair: %v", err)
 	}
 
-	if got, want := tlsCred.Key.Path, filepath.Join(tlsDirectory, fmt.Sprintf("%v.key", name)); got != want {
+	if got, want := tlsCred.Key.Path, filepath.Join(defaultConfDir, tlsDir, fmt.Sprintf("%v.key", name)); got != want {
 		t.Errorf("tlsCred.Key = %v, want %v", got, want)
 	}
-	if got, want := tlsCred.Cert.Path, filepath.Join(tlsDirectory, fmt.Sprintf("%v.crt", name)); got != want {
+	if got, want := tlsCred.Cert.Path, filepath.Join(defaultConfDir, tlsDir, fmt.Sprintf("%v.crt", name)); got != want {
 		t.Errorf("tlsCred.Crt = %v, want %v", got, want)
 	}
 

--- a/pkg/nghttpx/types.go
+++ b/pkg/nghttpx/types.go
@@ -31,8 +31,9 @@ import (
 
 // Interface is the API to update underlying load balancer.
 type Interface interface {
-	// Start starts a nghttpx process, and wait.  If stopCh becomes readable, kill nghttpx process, and return.
-	Start(stopCh <-chan struct{})
+	// Start starts a nghttpx process using executable at path with configuration file at confPath, and wait.  If stopCh becomes
+	// readable, kill nghttpx process, and return.
+	Start(path, confPath string, stopCh <-chan struct{})
 	// CheckAndReload checks whether the nghttpx configuration changed, and if so, make nghttpx reload its configuration.  If reloading
 	// is required, and it successfully issues reloading, returns true.  If there is no need to reloading, it returns false.  On error,
 	// it returns false, and non-nil error.
@@ -57,6 +58,12 @@ type IngressConfig struct {
 	HealthPort int
 	// APIPort is the port for API endpoint.
 	APIPort int
+	// ConfDir is the path to the directory which includes nghttpx configuration files.
+	ConfDir string
+	// HTTPPort is the port to listen to for HTTP (non-TLS) request.
+	HTTPPort int
+	// HTTPSPort is the port to listen to for HTTPS (TLS) request.
+	HTTPSPort int
 }
 
 // NewIngressConfig returns new IngressConfig.  Workers is initialized as the number of CPU cores.


### PR DESCRIPTION
The following flags are added:

* --nghttpx-conf-dir: path to nghttpx configuration directory.
* --nghttpx-exec-path: path to nghttpx executable.
* --nghttpx-http-port: port to listen to for HTTP requests.
* --nghttpx-https-port: port to listen to for HTTPS requests.

This commit also fixes the potential race that the default
configuration file is overwritten by the new configuration file while
nghttpx is reading the default one.