### PR TITLE
Make use of hostNetwork

### DIFF
--- a/examples/custom-configuration/rc-custom-configuration.yaml
+++ b/examples/custom-configuration/rc-custom-configuration.yaml
@@ -17,6 +17,7 @@ spec:
         name: nghttpx-ingress-lb
     spec:
       terminationGracePeriodSeconds: 60
+      hostNetwork: true
       containers:
       - image: zlabjp/nghttpx-ingress-controller:latest
         name: nghttpx-ingress-lb
@@ -25,7 +26,7 @@ spec:
           httpGet:
             path: /healthz
             # when changing this port, also specify it using --healthz-port in nghttpx-ingress-controller args.
-            port: 10249
+            port: 11249
             scheme: HTTP
           initialDelaySeconds: 30
           timeoutSeconds: 5
@@ -48,3 +49,4 @@ spec:
         - /nghttpx-ingress-controller
         - --default-backend-service=default/default-http-backend
         - --nghttpx-configmap=default/nghttpx-ingress-lb
+        - --healthz-port=11249

--- a/examples/daemonset/as-daemonset.yaml
+++ b/examples/daemonset/as-daemonset.yaml
@@ -14,6 +14,7 @@ spec:
     spec:
       serviceAccountName: ingress
       terminationGracePeriodSeconds: 60
+      hostNetwork: true
       containers:
       - image: zlabjp/nghttpx-ingress-controller:latest
         name: nghttpx-ingress-lb
@@ -22,7 +23,7 @@ spec:
           httpGet:
             path: /healthz
             # when changing this port, also specify it using --healthz-port in nghttpx-ingress-controller args.
-            port: 10249
+            port: 11249
             scheme: HTTP
           initialDelaySeconds: 30
           timeoutSeconds: 5
@@ -44,4 +45,5 @@ spec:
         args:
         - /nghttpx-ingress-controller
         - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
+        - --healthz-port=11249
         - --logtostderr

--- a/examples/default/rc-default.yaml
+++ b/examples/default/rc-default.yaml
@@ -16,6 +16,7 @@ spec:
     spec:
       serviceAccountName: ingress
       terminationGracePeriodSeconds: 60
+      hostNetwork: true
       containers:
       - image: zlabjp/nghttpx-ingress-controller:latest
         name: nghttpx-ingress-lb
@@ -24,7 +25,7 @@ spec:
           httpGet:
             path: /healthz
             # when changing this port, also specify it using --healthz-port in nghttpx-ingress-controller args.
-            port: 10249
+            port: 11249
             scheme: HTTP
           initialDelaySeconds: 30
           timeoutSeconds: 5
@@ -46,5 +47,6 @@ spec:
         args:
         - /nghttpx-ingress-controller
         - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
+        - --healthz-port=11249
         - --logtostderr
 

--- a/rc.yaml
+++ b/rc.yaml
@@ -73,6 +73,7 @@ spec:
     spec:
       serviceAccountName: ingress
       terminationGracePeriodSeconds: 60
+      hostNetwork: true
       containers:
       - image: zlabjp/nghttpx-ingress-controller:latest
         name: nghttpx-ingress-lb
@@ -80,7 +81,7 @@ spec:
           httpGet:
             path: /healthz
             # when changing this port, also specify it using --healthz-port in nghttpx-ingress-controller args.
-            port: 10249
+            port: 11249
             scheme: HTTP
           initialDelaySeconds: 30
           timeoutSeconds: 5
@@ -102,4 +103,5 @@ spec:
         args:
         - /nghttpx-ingress-controller
         - --default-backend-service=default/default-http-backend
+        - --healthz-port=11249
         - --logtostderr


### PR DESCRIPTION
Because CNI cannot handle hostPort at the moment, we have to use
hostNetwork in order to workaround it.

Fixes #48 