### PR TITLE
Add `proxyproto` flag.

### DIFF
--- a/cmd/nghttpx-ingress-controller/main.go
+++ b/cmd/nghttpx-ingress-controller/main.go
@@ -112,6 +112,9 @@ var (
 	fetchOCSPRespFromSecret = flags.Bool("fetch-ocsp-resp-from-secret", false,
 		`Fetch OCSP response from TLS secret.`)
 
+	proxyProto = flags.Bool("proxy-proto", false,
+		`Enable proxyproto for all public-facing frontends (api and health frontends are ignored)`)
+
 	ocspRespKey = flags.String("ocsp-resp-key", "tls.ocsp-resp", `A key for OCSP response in TLS secret.`)
 
 	configOverrides clientcmd.ConfigOverrides
@@ -205,6 +208,7 @@ func main() {
 		AllowInternalIP:         *allowInternalIP,
 		OCSPRespKey:             *ocspRespKey,
 		FetchOCSPRespFromSecret: *fetchOCSPRespFromSecret,
+		ProxyProto:              *proxyProto,
 	}
 
 	if err := generateDefaultNghttpxConfig(*nghttpxConfDir, *nghttpxHealthPort, *nghttpxAPIPort); err != nil {

--- a/examples/proxyproto/00-loadbalancer.yaml
+++ b/examples/proxyproto/00-loadbalancer.yaml
@@ -1,0 +1,19 @@
+# Kubernetes LoadBalancer ELB configuration, which forwards traffic
+# on ports 80 and 443 to an nghttpx-ingress-lb controller.
+# Kubernetes enabled the PROXY protocol on the AWS ELB.
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: '*'
+  name: nghttpx-ingress
+  namespace: kube-system
+spec:
+  selector:
+    k8s-app: nghttpx-ingress-lb
+  type: LoadBalancer
+  ports:
+  - name: http-ingress
+    port: 80
+  - name: tls-ingress
+    port: 443

--- a/examples/proxyproto/01-default-backend.yaml
+++ b/examples/proxyproto/01-default-backend.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-http-backend
+  namespace: kube-system
+  labels:
+    k8s-app: default-http-backend
+spec:
+  selector:
+    k8s-app: default-http-backend
+  ports:
+  - name: 8080-8080
+    port: 8080
+    targetPort: 8080
+    protocol: TCP
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: default-http-backend
+  namespace: kube-system
+spec:
+  revisionHistoryLimit: 5
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        k8s-app: default-http-backend
+    spec:
+      terminationGracePeriodSeconds: 60
+      containers:
+      - name: default-http-backend
+        # Any image is permissable as long as:
+        # 1. It serves a 404 page at /
+        # 2. It serves 200 on a /healthz endpoint
+        image: gcr.io/google_containers/defaultbackend:1.3
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        ports:
+        - containerPort: 8080
+        resources:
+          limits:
+            cpu: 10m
+            memory: 20Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi

--- a/examples/proxyproto/02-nghttpx-rbac.yaml
+++ b/examples/proxyproto/02-nghttpx-rbac.yaml
@@ -1,0 +1,127 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nghttpx-ingress-serviceaccount
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: nghttpx-ingress-clusterrole
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - endpoints
+      - nodes
+      - pods
+      - secrets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "extensions"
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+        - events
+    verbs:
+        - create
+        - patch
+  - apiGroups:
+      - "extensions"
+    resources:
+      - ingresses/status
+    verbs:
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: nhttpx-ingress-role
+  namespace: kube-system
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - pods
+      - secrets
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      # Defaults to "<election-id>-<ingress-class>"
+      # Here: "<ingress-controller-leader>-<nginx>"
+      # This has to be adapted if you change either parameter
+      # when launching the nginx-ingress-controller.
+      - "ingress-controller-leader-nginx"
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - get
+      - create
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: nghttpx-ingress-role-nisa-binding
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nghttpx-ingress-role
+subjects:
+  - kind: ServiceAccount
+    name: nhttpx-ingress-serviceaccount
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: nghttpx-ingress-clusterrole-nisa-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nghttpx-ingress-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: nghttpx-ingress-serviceaccount
+    namespace: kube-system

--- a/examples/proxyproto/03-nghttpx.yaml
+++ b/examples/proxyproto/03-nghttpx.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nghttpx-ingress-lb-config
+  namespace: kube-system
+data:
+  nghttpx-conf: |
+    add-x-forwarded-for=yes
+    strip-incoming-x-forwarded-for=yes
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: nghttpx-ingress-controller
+  namespace: kube-system
+  labels:
+    k8s-app: nghttpx-ingress-lb
+spec:
+  template:
+    metadata:
+      labels:
+        k8s-app: nghttpx-ingress-lb
+        name: nghttpx-ingress-lb
+    spec:
+      serviceAccountName: nghttpx-ingress-serviceaccount
+      terminationGracePeriodSeconds: 60
+      hostNetwork: true # disable this if you do not need CNI
+      containers:
+      - image: zlabjp/nghttpx-ingress-controller:latest
+        name: nghttpx-ingress-lb
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            # when changing this port, also specify it using --healthz-port in nghttpx-ingress-controller args.
+            port: 11249
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        # use downward API
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        ports:
+        - name: http-ingress
+          containerPort: 80
+          hostPort: 80
+        - name: tls-ingress
+          containerPort: 443
+          hostPort: 443
+        args:
+        - /nghttpx-ingress-controller
+        - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
+        - --nghttpx-configmap=$(POD_NAMESPACE)/nghttpx-ingress-lb-config
+        - --healthz-port=11249
+        - --logtostderr
+        - --proxy-proto=true

--- a/examples/proxyproto/README.md
+++ b/examples/proxyproto/README.md
@@ -1,0 +1,8 @@
+Creates an nghttpx-ingress-lb DaemonSet behind an AWS ELB.
+
+- ClientIP addresses are preserved by enabling the PROXY-protocol.
+- Use `X-Forwarded-For` header in your downstream backend to access the
+  ClientIP.
+- RBAC is enabled.
+- Hostnetwork=true (needed when you run a CNI-plugin [Flannel,Weave,Calico]).  Remove this param if you do not need it.
+

--- a/nghttpx.tmpl
+++ b/nghttpx.tmpl
@@ -2,13 +2,13 @@ accesslog-file=/dev/stdout
 
 include={{ .ConfDir }}/nghttpx-backend.conf
 
-frontend=*,{{ .HTTPPort }};no-tls
+frontend=*,{{ .HTTPPort }};no-tls{{ if .ProxyProto }};proxyproto{{ end }}
 
 # API endpoints
 frontend=127.0.0.1,{{ .APIPort }};api;no-tls
 
 {{ if .TLS }}
-frontend=*,{{ .HTTPSPort }}
+frontend=*,{{ .HTTPSPort }}{{ if .ProxyProto }};proxyproto{{ end }}
 
 {{ $defaultCred := .DefaultTLSCred }}
 # checksum is required to detect changes in the generated configuration and force a reload
@@ -23,7 +23,7 @@ subcert={{ $cred.Key.Path }}:{{ $cred.Cert.Path }}
 
 {{ else }}
 # just listen {{ .HTTPSPort }} to gain port {{ .HTTPSPort }}, so that we can always bind that address.
-frontend=*,{{ .HTTPSPort }};no-tls
+frontend=*,{{ .HTTPSPort }};no-tls{{ if .ProxyProto }};proxyproto{{ end }}
 {{ end }}
 
 # for health check

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -101,6 +101,7 @@ type LoadBalancerController struct {
 	allowInternalIP         bool
 	ocspRespKey             string
 	fetchOCSPRespFromSecret bool
+	proxyProto              bool
 
 	recorder record.EventRecorder
 
@@ -147,6 +148,8 @@ type Config struct {
 	AllowInternalIP         bool
 	OCSPRespKey             string
 	FetchOCSPRespFromSecret bool
+	// ProxyProto toggles the use of PROXY protocol for all public-facing frontends.
+	ProxyProto bool
 }
 
 // NewLoadBalancerController creates a controller for nghttpx loadbalancer
@@ -174,6 +177,7 @@ func NewLoadBalancerController(clientset clientset.Interface, manager nghttpx.In
 		allowInternalIP:         config.AllowInternalIP,
 		ocspRespKey:             config.OCSPRespKey,
 		fetchOCSPRespFromSecret: config.FetchOCSPRespFromSecret,
+		proxyProto:              config.ProxyProto,
 		recorder:                eventBroadcaster.NewRecorder(api.Scheme, clientv1.EventSource{Component: "nghttpx-ingress-controller"}),
 		syncQueue:               workqueue.New(),
 		reloadRateLimiter:       flowcontrol.NewTokenBucketRateLimiter(1.0, 1),
@@ -789,6 +793,7 @@ func (lbc *LoadBalancerController) getUpstreamServers(ings []*extensions.Ingress
 	ingConfig.HTTPPort = lbc.nghttpxHTTPPort
 	ingConfig.HTTPSPort = lbc.nghttpxHTTPSPort
 	ingConfig.FetchOCSPRespFromSecret = lbc.fetchOCSPRespFromSecret
+	ingConfig.ProxyProto = lbc.proxyProto
 
 	var (
 		upstreams []*nghttpx.Upstream

--- a/pkg/nghttpx/types.go
+++ b/pkg/nghttpx/types.go
@@ -66,6 +66,8 @@ type IngressConfig struct {
 	HTTPSPort int
 	// FetchOCSPRespFromSecret is true if OCSP response is fetched from TLS secret.
 	FetchOCSPRespFromSecret bool
+	// ProxyProto toggles the use of PROXY protocol for all public-facing frontends.
+	ProxyProto bool
 }
 
 // NewIngressConfig returns new IngressConfig.  Workers is initialized as the number of CPU cores.


### PR DESCRIPTION
Fixes https://github.com/zlabjp/nghttpx-ingress-lb/issues/59

The proxyproto param enables the PROXY protocol for all frontends,
which are public-facing, i.e. the API- and HEALTH frontend are ignored.

The definition of how to enable the PROXY protocol can be found in:

https://nghttp2.org/documentation/nghttpx-howto.html#enable-proxy-protocol