### PR TITLE
Add default-backend-config annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,35 @@ spec:
           servicePort: 50051
 ```
 
+The controller also understands
+`ingress.zlab.co.jp/default-backend-config` annotation.  It serves
+default values for missing values in backend-config per field basis in
+the same Ingress resource.  It can contain single dictionary which
+contains the same key/value pairs.  It is useful if same set of
+backend-config is required for lots of services.
+
+For example, if a pair of service, and port has the backend-config
+like so:
+
+```json
+{"affinity": "ip"}
+```
+
+And the default-backend-config looks like so:
+
+```json
+{"proto": "h2", "affinity": "none"}
+```
+
+The final backend-config becomes like so:
+
+```json
+{"proto": "h2", "affinity": "ip"}
+```
+
+A values which specified explicitly in an individual backend-config
+always takes precedence.
+
 Note that Ingress allows regular expression in
 `.spec.rules[*].http.paths[*].path`, but nghttpx does not support it.
 

--- a/pkg/controller/annotation.go
+++ b/pkg/controller/annotation.go
@@ -19,25 +19,54 @@ import (
 const (
 	// backendConfigKey is a key to annotation for extra backend configuration.
 	backendConfigKey = "ingress.zlab.co.jp/backend-config"
+	// defaultBackendConfigKey is a key to annotation for default backend configuration which applies to all entries in a Ingress
+	// resource.
+	defaultBackendConfigKey = "ingress.zlab.co.jp/default-backend-config"
 	// ingressClassKey is a key to annotation in order to run multiple Ingress controllers.
 	ingressClassKey = "kubernetes.io/ingress.class"
 )
 
 type ingressAnnotation map[string]string
 
-func (ia ingressAnnotation) getBackendConfig() map[string]map[string]nghttpx.PortBackendConfig {
+// getBackendConfig returns default-backend-config, and backend-config.  This function applies default-backend-config to backend-config if
+// it exists.  If invalid value is found, this function replaces them with the default value (e.g., nghttpx.ProtocolH1 for proto).
+func (ia ingressAnnotation) getBackendConfig() (*nghttpx.PortBackendConfig, map[string]map[string]*nghttpx.PortBackendConfig) {
 	data := ia[backendConfigKey]
 	// the first key specifies service name, and secondary key specifies port name.
-	var config map[string]map[string]nghttpx.PortBackendConfig
-	if data == "" {
-		return config
-	}
-	if err := json.Unmarshal([]byte(data), &config); err != nil {
-		glog.Errorf("unexpected error reading %v annotation: %v", backendConfigKey, err)
-		return config
+	var config map[string]map[string]*nghttpx.PortBackendConfig
+	if data != "" {
+		if err := json.Unmarshal([]byte(data), &config); err != nil {
+			glog.Errorf("unexpected error reading %v annotation: %v", backendConfigKey, err)
+			return nil, nil
+		}
 	}
 
-	return config
+	for _, v := range config {
+		for _, vv := range v {
+			nghttpx.FixupPortBackendConfig(vv)
+		}
+	}
+
+	data = ia[defaultBackendConfigKey]
+	if data == "" {
+		glog.V(4).Infof("%v annotation not found", defaultBackendConfigKey)
+		return nil, config
+	}
+
+	var defaultConfig nghttpx.PortBackendConfig
+	if err := json.Unmarshal([]byte(data), &defaultConfig); err != nil {
+		glog.Errorf("unexpected error reading %v annotation: %v", defaultBackendConfigKey, err)
+		return nil, nil
+	}
+	nghttpx.FixupPortBackendConfig(&defaultConfig)
+
+	for _, v := range config {
+		for _, vv := range v {
+			nghttpx.ApplyDefaultPortBackendConfig(vv, &defaultConfig)
+		}
+	}
+
+	return &defaultConfig, config
 }
 
 // getIngressClass returns Ingress class from annotation.

--- a/pkg/controller/annotation_test.go
+++ b/pkg/controller/annotation_test.go
@@ -1,0 +1,76 @@
+package controller
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/zlabjp/nghttpx-ingress-lb/pkg/nghttpx"
+)
+
+// TestGetBackendConfig verifies getBackendConfig.
+func TestGetBackendConfig(t *testing.T) {
+	tests := []struct {
+		annotationDefaultConfig string
+		annotationConfig        string
+		wantDefaultConfig       *nghttpx.PortBackendConfig
+		wantConfig              map[string]map[string]*nghttpx.PortBackendConfig
+	}{
+		// 0
+		{
+			annotationConfig: `{"svc": {"80": {"proto": "h2"}}}`,
+			wantConfig: map[string]map[string]*nghttpx.PortBackendConfig{
+				"svc": {
+					"80": func() *nghttpx.PortBackendConfig {
+						a := &nghttpx.PortBackendConfig{}
+						a.SetProto(nghttpx.ProtocolH2)
+						return a
+					}(),
+				},
+			},
+		},
+		// 1
+		{
+			annotationDefaultConfig: `{"affinity": "ip"}`,
+			wantDefaultConfig: func() *nghttpx.PortBackendConfig {
+				a := &nghttpx.PortBackendConfig{}
+				a.SetAffinity(nghttpx.AffinityIP)
+				return a
+			}(),
+		},
+		// 2
+		{
+			annotationDefaultConfig: `{"affinity": "ip"}`,
+			annotationConfig:        `{"svc": {"80": {"proto": "h2"}}}`,
+			wantDefaultConfig: func() *nghttpx.PortBackendConfig {
+				a := &nghttpx.PortBackendConfig{}
+				a.SetAffinity(nghttpx.AffinityIP)
+				return a
+			}(),
+			wantConfig: map[string]map[string]*nghttpx.PortBackendConfig{
+				"svc": {
+					"80": func() *nghttpx.PortBackendConfig {
+						a := &nghttpx.PortBackendConfig{}
+						a.SetProto(nghttpx.ProtocolH2)
+						a.SetAffinity(nghttpx.AffinityIP)
+						return a
+					}(),
+				},
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		ann := ingressAnnotation(map[string]string{
+			defaultBackendConfigKey: tt.annotationDefaultConfig,
+			backendConfigKey:        tt.annotationConfig,
+		})
+		defaultConfig, config := ann.getBackendConfig()
+
+		if !reflect.DeepEqual(defaultConfig, tt.wantDefaultConfig) {
+			t.Errorf("#%v: defaultConfig = %+v, want %+v", i, defaultConfig, tt.wantDefaultConfig)
+		}
+		if !reflect.DeepEqual(config, tt.wantConfig) {
+			t.Errorf("#%v: config = %+v, want %+v", i, config, tt.wantConfig)
+		}
+	}
+}

--- a/pkg/nghttpx/types.go
+++ b/pkg/nghttpx/types.go
@@ -89,17 +89,17 @@ type Upstream struct {
 type Affinity string
 
 const (
-	AffinityNone = "none"
-	AffinityIP   = "ip"
+	AffinityNone Affinity = "none"
+	AffinityIP   Affinity = "ip"
 )
 
 type Protocol string
 
 const (
 	// HTTP/2 protocol
-	ProtocolH2 = "h2"
+	ProtocolH2 Protocol = "h2"
 	// HTTP/1.1 protocol
-	ProtocolH1 = "http/1.1"
+	ProtocolH1 Protocol = "http/1.1"
 )
 
 // UpstreamServer describes a server in an nghttpx upstream
@@ -123,9 +123,8 @@ type TLSCred struct {
 // NewDefaultServer return an UpstreamServer to be use as default server that returns 503.
 func NewDefaultServer() UpstreamServer {
 	return UpstreamServer{
-		Address: "127.0.0.1",
-		Port:    "8181",
-		// Update DefaultPortBackendConfig() too.
+		Address:  "127.0.0.1",
+		Port:     "8181",
 		Protocol: ProtocolH1,
 		Affinity: AffinityNone,
 	}
@@ -134,15 +133,75 @@ func NewDefaultServer() UpstreamServer {
 // backend configuration obtained from ingress annotation, specified per service port
 type PortBackendConfig struct {
 	// backend application protocol.  At the moment, this should be either ProtocolH2 or ProtocolH1.
-	Proto Protocol `json:"proto,omitempty"`
+	Proto *Protocol `json:"proto,omitempty"`
 	// true if backend connection requires TLS
-	TLS bool `json:"tls,omitempty"`
+	TLS *bool `json:"tls,omitempty"`
 	// SNI hostname for backend TLS connection
-	SNI string `json:"sni,omitempty"`
+	SNI *string `json:"sni,omitempty"`
 	// DNS is true if backend hostname is resolved dynamically rather than start up or configuration reloading.
-	DNS bool `json:"dns,omitempty"`
+	DNS *bool `json:"dns,omitempty"`
 	// Affinity is session affinity method nghttpx supports.  See affinity parameter in backend option of nghttpx.
-	Affinity Affinity `json:"affinity,omitempty"`
+	Affinity *Affinity `json:"affinity,omitempty"`
+}
+
+func (pbc *PortBackendConfig) GetProto() Protocol {
+	if pbc.Proto == nil {
+		return ""
+	}
+	return *pbc.Proto
+}
+
+func (pbc *PortBackendConfig) SetProto(proto Protocol) {
+	pbc.Proto = new(Protocol)
+	*pbc.Proto = proto
+}
+
+func (pbc *PortBackendConfig) GetTLS() bool {
+	if pbc.TLS == nil {
+		return false
+	}
+	return *pbc.TLS
+}
+
+func (pbc *PortBackendConfig) SetTLS(tls bool) {
+	pbc.TLS = new(bool)
+	*pbc.TLS = tls
+}
+
+func (pbc *PortBackendConfig) GetSNI() string {
+	if pbc.SNI == nil {
+		return ""
+	}
+	return *pbc.SNI
+}
+
+func (pbc *PortBackendConfig) SetSNI(sni string) {
+	pbc.SNI = new(string)
+	*pbc.SNI = sni
+}
+
+func (pbc *PortBackendConfig) GetDNS() bool {
+	if pbc.DNS == nil {
+		return false
+	}
+	return *pbc.DNS
+}
+
+func (pbc *PortBackendConfig) SetDNS(dns bool) {
+	pbc.DNS = new(bool)
+	*pbc.DNS = dns
+}
+
+func (pbc *PortBackendConfig) GetAffinity() Affinity {
+	if pbc.Affinity == nil {
+		return AffinityNone
+	}
+	return *pbc.Affinity
+}
+
+func (pbc *PortBackendConfig) SetAffinity(affinity Affinity) {
+	pbc.Affinity = new(Affinity)
+	*pbc.Affinity = affinity
 }
 
 // ChecksumFile represents a file with path, its arbitrary content, and its checksum.

--- a/pkg/nghttpx/utils_test.go
+++ b/pkg/nghttpx/utils_test.go
@@ -15,42 +15,106 @@ import (
 // TestFixupPortBackendConfig validates fixupPortBackendConfig corrects invalid input to the correct default value.
 func TestFixupPortBackendConfig(t *testing.T) {
 	tests := []struct {
-		in  PortBackendConfig
-		out PortBackendConfig
+		inProto     Protocol
+		inAffinity  Affinity
+		outProto    Protocol
+		outAffinity Affinity
 	}{
+		// 0
 		{
-			in: PortBackendConfig{
-				Proto:    "foo",
-				Affinity: "bar",
-			},
-			out: PortBackendConfig{
-				Proto:    ProtocolH1,
-				Affinity: AffinityNone,
-			},
+			inProto:     "foo",
+			inAffinity:  "bar",
+			outProto:    ProtocolH1,
+			outAffinity: AffinityNone,
 		},
+		// 1
 		{
-			// Empty Proto and Affinity should be replaced with default values.
-			out: PortBackendConfig{
-				Proto:    ProtocolH1,
-				Affinity: AffinityNone,
-			},
+		// Empty input leaves as is.
 		},
+		// 2
 		{
 			// Correct input must be left unchanged.
-			in: PortBackendConfig{
-				Proto:    ProtocolH2,
-				Affinity: AffinityIP,
-			},
-			out: PortBackendConfig{
-				Proto:    ProtocolH2,
-				Affinity: AffinityIP,
-			},
+			inProto:     ProtocolH2,
+			inAffinity:  AffinityIP,
+			outProto:    ProtocolH2,
+			outAffinity: AffinityIP,
 		},
 	}
 
 	for i, tt := range tests {
-		if got, want := FixupPortBackendConfig(tt.in, "svc", "port"), tt.out; got != want {
-			t.Errorf("#%v: fixupPortBackendConfig(%+v) = %+v, want %+v", i, tt.in, got, want)
+		c := &PortBackendConfig{}
+		c.SetProto(tt.inProto)
+		c.SetAffinity(tt.inAffinity)
+		FixupPortBackendConfig(c)
+		if got, want := c.GetProto(), tt.outProto; got != want {
+			t.Errorf("#%v: c.GetProto() = %q, want %q", i, got, want)
+		}
+		if got, want := c.GetAffinity(), tt.outAffinity; got != want {
+			t.Errorf("#%v: c.GetAffinity() = %q, want %q", i, got, want)
+		}
+	}
+}
+
+// TestApplyDefaultPortBackendConfig verifies ApplyDefaultPortBackendConfig.
+func TestApplyDefaultPortBackendConfig(t *testing.T) {
+	tests := []struct {
+		defaultConf *PortBackendConfig
+	}{
+		{
+			defaultConf: func() *PortBackendConfig {
+				a := &PortBackendConfig{}
+				a.SetProto(ProtocolH2)
+				return a
+			}(),
+		},
+		{
+			defaultConf: func() *PortBackendConfig {
+				a := &PortBackendConfig{}
+				a.SetTLS(true)
+				return a
+			}(),
+		},
+		{
+			defaultConf: func() *PortBackendConfig {
+				a := &PortBackendConfig{}
+				a.SetSNI("example.com")
+				return a
+			}(),
+		},
+		{
+			defaultConf: func() *PortBackendConfig {
+				a := &PortBackendConfig{}
+				a.SetDNS(true)
+				return a
+			}(),
+		},
+		{
+			defaultConf: func() *PortBackendConfig {
+				a := &PortBackendConfig{}
+				a.SetAffinity(AffinityIP)
+				return a
+			}(),
+		},
+	}
+
+	for i, tt := range tests {
+		a := &PortBackendConfig{}
+		ApplyDefaultPortBackendConfig(a, tt.defaultConf)
+
+		if got, want := a.GetProto(), tt.defaultConf.GetProto(); got != want {
+			t.Errorf("#%v: a.GetProto() = %v, want %v", i, got, want)
+		}
+		if got, want := a.GetTLS(), tt.defaultConf.GetTLS(); got != want {
+			t.Errorf("#%v: a.GetTLS() = %v, want %v", i, got, want)
+		}
+		if got, want := a.GetSNI(), tt.defaultConf.GetSNI(); got != want {
+			t.Errorf("#%v: a.GetSNI() = %v, want %v", i, got, want)
+		}
+		if got, want := a.GetDNS(), tt.defaultConf.GetDNS(); got != want {
+			t.Errorf("#%v: a.GetDNS() = %v, want %v", i, got, want)
+		}
+		if got, want := a.GetAffinity(), tt.defaultConf.GetAffinity(); got != want {
+			t.Errorf("#%v: a.GetAffinity() = %v, want %v", i, got, want)
 		}
 	}
 }


### PR DESCRIPTION
default-backend-config annotation provides a default value of missing
backend-config per field basis.

For example, if a pair of service and port has a following backend-config:

{"affinity": "ip"}

And if default-backend-config looks like so:

{"proto": "h2"}

The final backend-config for the service and port becomes like so:

{"proto": "h2", "affinity": "ip"}

Fixes #63 