### PR TITLE
Make affinityCookieSecure default to "auto"

### DIFF
--- a/pkg/nghttpx/types.go
+++ b/pkg/nghttpx/types.go
@@ -361,7 +361,7 @@ func (pc *PathConfig) SetAffinityCookiePath(affinityCookiePath string) {
 
 func (pc *PathConfig) GetAffinityCookieSecure() AffinityCookieSecure {
 	if pc == nil || pc.AffinityCookieSecure == nil {
-		return ""
+		return AffinityCookieSecureAuto
 	}
 	return *pc.AffinityCookieSecure
 }


### PR DESCRIPTION
The document says that if affinityCookieSecure is set to empty string,
it defaults to "auto".  But previously the code just leaves it as is,
and nghttpx rejects it.  This commit makes sure that empty
affinityCookieSecure defaults to "auto".