### PR TITLE
Build nghttpx statically and use distroless image to shrink image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,44 +17,29 @@
 # For the full copyright and license information, please view the LICENSE
 # file that was distributed with this source code.
 
-FROM ubuntu:20.04
+FROM debian:buster as build
 
-COPY extra-mrbgem.patch /
+COPY extra-mrbgem.patch static.patch /
 
 # Inspired by clean-install https://github.com/kubernetes/kubernetes/blob/73641d35c7622ada9910be6fb212d40755cc1f78/build/debian-base/clean-install
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         git g++ make binutils autoconf automake autotools-dev libtool pkg-config \
-        zlib1g-dev libev-dev libjemalloc-dev ruby-dev libc-ares-dev libssl-dev bison patch \
-        zlib1g libev4 libjemalloc2 libc-ares2 \
-        ca-certificates openssl && \
-    apt-get clean -y && \
+        zlib1g-dev libev-dev libjemalloc-dev ruby-dev libc-ares-dev libssl-dev bison patch && \
     git clone --depth 1 -b v1.41.0 https://github.com/nghttp2/nghttp2.git && \
     cd nghttp2 && \
     patch -p1 < /extra-mrbgem.patch && \
+    patch -p1 < /static.patch && \
     git submodule update --init && \
     autoreconf -i && \
     ./configure --disable-examples --disable-hpack-tools --disable-python-bindings --with-mruby --with-neverbleed && \
-    make -j$(nproc) install-strip && \
-    cd .. && \
-    rm -rf nghttp2 && \
-    apt-get -y purge git g++ make binutils autoconf automake autotools-dev libtool pkg-config \
-        zlib1g-dev libev-dev libjemalloc-dev ruby-dev libc-ares-dev libssl-dev bison patch && \
-    apt-get -y autoremove --purge && \
-    rm -rf \
-        /var/cache/debconf/* \
-        /var/lib/apt/lists/* \
-        /var/log/* \
-        /tmp/* \
-        /var/tmp/* && \
-    rm /extra-mrbgem.patch
+    make -j$(nproc) install-strip
 
-RUN mkdir -p /var/log/nghttpx
+FROM gcr.io/distroless/cc-debian10@sha256:fdc2db094a9ceaaf7cc3458a5f8987c1b68396dbc27bfab3a594cbe911c705d1
 
-COPY nghttpx-ingress-controller fetch-ocsp-response cat-ocsp-resp /
-COPY nghttpx.tmpl /
-COPY nghttpx-backend.tmpl /
-COPY default.tmpl /
+COPY --from=build /usr/local/bin/nghttpx /usr/local/bin/
+COPY image/var/log/nghttpx /var/log/nghttpx
+COPY nghttpx-ingress-controller fetch-ocsp-response cat-ocsp-resp nghttpx.tmpl nghttpx-backend.tmpl default.tmpl /
 
 WORKDIR /
 

--- a/image/var/log/nghttpx/.gitignore
+++ b/image/var/log/nghttpx/.gitignore
@@ -1,0 +1,1 @@
+!.gitignore

--- a/static.patch
+++ b/static.patch
@@ -1,0 +1,51 @@
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 03821648..d1fd78f2 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -49,17 +49,21 @@ AM_CPPFLAGS = \
+ 	@ZLIB_CFLAGS@ \
+ 	@DEFS@
+ 
++AM_LDFLAGS = -static-libtool-libs
++
+ LDADD = $(top_builddir)/lib/libnghttp2.la \
+ 	$(top_builddir)/third-party/liburl-parser.la \
+ 	$(top_builddir)/third-party/libllhttp.la \
+-	@JEMALLOC_LIBS@ \
++	${top_builddir}/third-party/libneverbleed.la \
++	/usr/lib/x86_64-linux-gnu/libjemalloc.a \
+ 	@LIBXML2_LIBS@ \
+-	@LIBEV_LIBS@ \
+-	@OPENSSL_LIBS@ \
+-	@LIBCARES_LIBS@ \
++	/usr/lib/x86_64-linux-gnu/libev.a \
++	/usr/lib/x86_64-linux-gnu/libssl.a \
++	/usr/lib/x86_64-linux-gnu/libcrypto.a \
++	/usr/lib/x86_64-linux-gnu/libcares.a \
+ 	@SYSTEMD_LIBS@ \
+ 	@JANSSON_LIBS@ \
+-	@ZLIB_LIBS@ \
++	/usr/lib/x86_64-linux-gnu/libz.a \
+ 	@APPLDFLAGS@
+ 
+ if ENABLE_APP
+@@ -169,7 +173,6 @@ endif # HAVE_MRUBY
+ 
+ if HAVE_NEVERBLEED
+ libnghttpx_a_CPPFLAGS += -I${top_srcdir}/third-party/neverbleed
+-nghttpx_LDADD += ${top_builddir}/third-party/libneverbleed.la
+ endif # HAVE_NEVERBLEED
+ 
+ if HAVE_CUNIT
+diff --git a/third-party/Makefile.am b/third-party/Makefile.am
+index 59252362..73053d98 100644
+--- a/third-party/Makefile.am
++++ b/third-party/Makefile.am
+@@ -43,7 +43,6 @@ libllhttp_la_CPPFLAGS = -I${srcdir}/llhttp/include
+ if HAVE_NEVERBLEED
+ noinst_LTLIBRARIES += libneverbleed.la
+ libneverbleed_la_CPPFLAGS = @OPENSSL_CFLAGS@
+-libneverbleed_la_LIBADD = @OPENSSL_LIBS@
+ libneverbleed_la_SOURCES = neverbleed/neverbleed.c neverbleed/neverbleed.h
+ endif # HAVE_NEVERBLEED
+ 


### PR DESCRIPTION
Build nghttpx statically and use multi stage build to copy only
required files to runtime distroless/cc image which cuts image size to
half.  From this commit, only nghttpx binary is included.  Other
binaries which are included in the old images (e.g., h2load, nghttp
etc) are not included in new image.