### PR TITLE
Allow ':' in HTTP path

### DIFF
--- a/0001-Allow-percent-encoded-in-backend-pattern.patch
+++ b/0001-Allow-percent-encoded-in-backend-pattern.patch
@@ -1,0 +1,111 @@
+From 1d724f0d10015946c67e6262400f9d6a895f9abb Mon Sep 17 00:00:00 2001
+From: Tatsuhiro Tsujikawa <ttsujika@zlab.co.jp>
+Date: Thu, 26 Nov 2020 05:39:57 +0000
+Subject: [PATCH] Allow percent-encoded ':' in backend pattern
+
+---
+ src/http2.cc        | 54 +++++++++++++++++++++++++++++++++++++++++++++
+ src/http2.h         |  4 ++++
+ src/shrpx_config.cc |  6 ++---
+ 3 files changed, 61 insertions(+), 3 deletions(-)
+
+diff --git a/src/http2.cc b/src/http2.cc
+index c5b596f4..11ae7167 100644
+--- a/src/http2.cc
++++ b/src/http2.cc
+@@ -1841,6 +1841,60 @@ StringRef normalize_path(BlockAllocator &balloc, const StringRef &path,
+                    query);
+ }
+ 
++StringRef normalize_path_extra_colon(BlockAllocator &balloc,
++                                     const StringRef &path,
++                                     const StringRef &query) {
++  // First, decode %XX for unreserved characters, then do
++  // http2::path_join
++
++  // We won't find %XX if length is less than 3.
++  if (path.size() < 3 ||
++      std::find(std::begin(path), std::end(path), '%') == std::end(path)) {
++    return path_join(balloc, StringRef{}, StringRef{}, path, query);
++  }
++
++  // includes last terminal NULL.
++  auto result = make_byte_ref(balloc, path.size() + 1);
++  auto p = result.base;
++
++  auto it = std::begin(path);
++  for (; it + 2 < std::end(path);) {
++    if (*it == '%') {
++      if (util::is_hex_digit(*(it + 1)) && util::is_hex_digit(*(it + 2))) {
++        auto c =
++            (util::hex_to_uint(*(it + 1)) << 4) + util::hex_to_uint(*(it + 2));
++        // Special treatment for %3a (= ':').  ':' is not in the
++        // unreserved character set, but we use it in separator when
++        // parsing backend option, and it cannot appear in pattern
++        // although ':' is valid character.  In order to allow ':' in
++        // pattern, we perform percent-decoding %3a to produce ':'.
++        // User can specify %3a in pattern as an encoded form of ':'.
++        if (util::in_rfc3986_unreserved_chars(c) || c == ':') {
++          *p++ = c;
++
++          it += 3;
++
++          continue;
++        }
++        *p++ = '%';
++        *p++ = util::upcase(*(it + 1));
++        *p++ = util::upcase(*(it + 2));
++
++        it += 3;
++
++        continue;
++      }
++    }
++    *p++ = *it++;
++  }
++
++  p = std::copy(it, std::end(path), p);
++  *p = '\0';
++
++  return path_join(balloc, StringRef{}, StringRef{}, StringRef{result.base, p},
++                   query);
++}
++
+ std::string normalize_path(const StringRef &path, const StringRef &query) {
+   BlockAllocator balloc(1024, 1024);
+ 
+diff --git a/src/http2.h b/src/http2.h
+index b0b10651..d7490a56 100644
+--- a/src/http2.h
++++ b/src/http2.h
+@@ -410,6 +410,10 @@ StringRef to_method_string(int method_token);
+ StringRef normalize_path(BlockAllocator &balloc, const StringRef &path,
+                          const StringRef &query);
+ 
++StringRef normalize_path_extra_colon(BlockAllocator &balloc,
++                                     const StringRef &path,
++                                     const StringRef &query);
++
+ std::string normalize_path(const StringRef &path, const StringRef &query);
+ 
+ StringRef rewrite_clean_path(BlockAllocator &balloc, const StringRef &src);
+diff --git a/src/shrpx_config.cc b/src/shrpx_config.cc
+index 8f5cd507..00b21737 100644
+--- a/src/shrpx_config.cc
++++ b/src/shrpx_config.cc
+@@ -1109,9 +1109,9 @@ int parse_mapping(Config *config, DownstreamAddrConfig &addr,
+       *p = '\0';
+       pattern = StringRef{iov.base, p};
+     } else {
+-      auto path = http2::normalize_path(downstreamconf.balloc,
+-                                        StringRef{slash, std::end(raw_pattern)},
+-                                        StringRef{});
++      auto path = http2::normalize_path_extra_colon(
++          downstreamconf.balloc, StringRef{slash, std::end(raw_pattern)},
++          StringRef{});
+       auto iov = make_byte_ref(downstreamconf.balloc,
+                                std::distance(std::begin(raw_pattern), slash) +
+                                    path.size() + 1);
+-- 
+2.25.1
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@
 
 FROM debian:buster as build
 
-COPY extra-mrbgem.patch static.patch /
+COPY extra-mrbgem.patch static.patch 0001-Allow-percent-encoded-in-backend-pattern.patch /
 
 # Inspired by clean-install https://github.com/kubernetes/kubernetes/blob/73641d35c7622ada9910be6fb212d40755cc1f78/build/debian-base/clean-install
 RUN apt-get update && \
@@ -30,6 +30,7 @@ RUN apt-get update && \
     cd nghttp2 && \
     patch -p1 < /extra-mrbgem.patch && \
     patch -p1 < /static.patch && \
+    patch -p1 < /0001-Allow-percent-encoded-in-backend-pattern.patch && \
     git submodule update --init && \
     autoreconf -i && \
     ./configure --disable-examples --disable-hpack-tools --disable-python-bindings --with-mruby --with-neverbleed && \
@@ -45,7 +46,7 @@ RUN apt-get update && \
         /var/log/* \
         /tmp/* \
         /var/tmp/* && \
-    rm /extra-mrbgem.patch /static.patch
+    rm /extra-mrbgem.patch /static.patch /0001-Allow-percent-encoded-in-backend-pattern.patch
 
 FROM gcr.io/distroless/cc-debian10@sha256:b08f449377c84226d56d1c92bf89390f44488eacdfc8585c2db9873f378a5aa7
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1008,7 +1008,8 @@ func (lbc *LoadBalancerController) createUpstream(ing *networking.Ingress, host,
 	} else if !strings.HasPrefix(path, "/") {
 		return nil, fmt.Errorf("Host %v has Path which does not start /: %v", host, path)
 	} else {
-		normalizedPath = path
+		// nghttpx requires ':' to be percent-encoded.  Otherwise, ':' is recognized as pattern separator.
+		normalizedPath = strings.ReplaceAll(path, ":", "%3A")
 	}
 	pc := nghttpx.ResolvePathConfig(host, normalizedPath, defaultPathConfig, pathConfig)
 	// The format of upsName is similar to backend option syntax of nghttpx.


### PR DESCRIPTION
nghttpx does not allow ':' in pattern although it is a valid character
in URI path.  This commit includes a patch to instruct nghttpx to
recognized %3a (which is percent-encoded form of ':') as ':' in
pattern.  The change in Ingress controller code performs
percent-encoding against ':' so that this process is transparent to
users.