### PR TITLE
Migrate to networkingv1.Ingress

### DIFF
--- a/examples/ingress.yaml
+++ b/examples/ingress.yaml
@@ -1,5 +1,5 @@
 # An Ingress with 2 hosts and 3 endpoints
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: echomap
@@ -9,17 +9,26 @@ spec:
     http:
       paths:
       - path: /foo
+        pathType: ImplementationSpecific
         backend:
-          serviceName: echoheaders-x
-          servicePort: 80
+          service:
+            name: echoheaders-x
+            port:
+              number: 80
   - host: bar.baz.com
     http:
       paths:
       - path: /bar
+        pathType: ImplementationSpecific
         backend:
-          serviceName: echoheaders-y
-          servicePort: 80
+          service:
+            name: echoheaders-y
+            port:
+              number: 80
       - path: /foo
+        pathType: ImplementationSpecific
         backend:
-          serviceName: echoheaders-x
-          servicePort: 80
+          service:
+            name: echoheaders-x
+            port:
+              number: 80

--- a/pkg/controller/annotation.go
+++ b/pkg/controller/annotation.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 
 	"github.com/ghodss/yaml"
-	networking "k8s.io/api/networking/v1beta1"
 	"k8s.io/klog/v2"
 
 	"github.com/zlabjp/nghttpx-ingress-lb/pkg/nghttpx"
@@ -140,9 +139,4 @@ func unmarshal(data []byte, dest interface{}) error {
 		}
 	}
 	return nil
-}
-
-// getIngressClass returns Ingress class from annotation.
-func (ia ingressAnnotation) getIngressClass() string {
-	return ia[networking.AnnotationIngressClass]
 }


### PR DESCRIPTION
Migrate to networkingv1.Ingress.  The "kubernetes.io/ingress.class"
annotation support has been removed.  --ingress-class flag is also
deprecated.  IngressClass is enabled by default.