### PR TITLE
Use checksum as TLS key and certificate file name

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -27,6 +27,7 @@ package controller
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"fmt"
 	"reflect"
 	"testing"
@@ -721,17 +722,19 @@ func TestSyncDefaultSecret(t *testing.T) {
 		t.Errorf("ingConfig.TLS = %v, want %v", got, want)
 	}
 
-	prefix := nghttpx.TLSCredPrefix(tlsSecret)
-	if got, want := ingConfig.DefaultTLSCred.Key.Path, nghttpx.CreateTLSKeyPath(defaultConfDir, prefix); got != want {
+	dKeyChecksum := nghttpx.Checksum(dKey)
+	dCrtChecksum := nghttpx.Checksum(dCrt)
+
+	if got, want := ingConfig.DefaultTLSCred.Key.Path, nghttpx.CreateTLSKeyPath(defaultConfDir, hex.EncodeToString(dKeyChecksum)); got != want {
 		t.Errorf("ingConfig.DefaultTLSCred.Key.Path = %v, want %v", got, want)
 	}
-	if got, want := ingConfig.DefaultTLSCred.Cert.Path, nghttpx.CreateTLSCertPath(defaultConfDir, prefix); got != want {
+	if got, want := ingConfig.DefaultTLSCred.Cert.Path, nghttpx.CreateTLSCertPath(defaultConfDir, hex.EncodeToString(dCrtChecksum)); got != want {
 		t.Errorf("ingConfig.DefaultTLSCred.Cert.Path = %v, want %v", got, want)
 	}
-	if got, want := ingConfig.DefaultTLSCred.Key.Checksum, nghttpx.Checksum(dKey); !bytes.Equal(got, want) {
+	if got, want := ingConfig.DefaultTLSCred.Key.Checksum, dKeyChecksum; !bytes.Equal(got, want) {
 		t.Errorf("ingConfig.DefaultTLSCred.Key.Checksum = %x, want %x", got, want)
 	}
-	if got, want := ingConfig.DefaultTLSCred.Cert.Checksum, nghttpx.Checksum(dCrt); !bytes.Equal(got, want) {
+	if got, want := ingConfig.DefaultTLSCred.Cert.Checksum, dCrtChecksum; !bytes.Equal(got, want) {
 		t.Errorf("ingConfig.DefaultTLSCred.Cert.Checksum = %v, want %x", got, want)
 	}
 
@@ -773,8 +776,7 @@ func TestSyncDupDefaultSecret(t *testing.T) {
 		t.Errorf("ingConfig.TLS = %v, want %v", got, want)
 	}
 
-	prefix := nghttpx.TLSCredPrefix(tlsSecret)
-	if got, want := ingConfig.DefaultTLSCred.Key.Path, nghttpx.CreateTLSKeyPath(defaultConfDir, prefix); got != want {
+	if got, want := ingConfig.DefaultTLSCred.Key.Path, nghttpx.CreateTLSKeyPath(defaultConfDir, hex.EncodeToString(nghttpx.Checksum(dKey))); got != want {
 		t.Errorf("ingConfig.DefaultTLSCred.Key.Path = %v, want %v", got, want)
 	}
 	if got, want := len(ingConfig.SubTLSCred), 0; got != want {

--- a/pkg/nghttpx/nghttpx.tmpl
+++ b/pkg/nghttpx/nghttpx.tmpl
@@ -20,13 +20,9 @@ http2-altsvc=h3,{{ .HTTPSPort }},,,ma=3600
 http2-altsvc=h3-29,{{ .HTTPSPort }},,,ma=3600
 {{ end -}}
 # Default TLS credential
-{{ $defaultCred := .DefaultTLSCred -}}
-# checksum is required to detect changes in the generated configuration and force a reload
-# checksum: {{ encodeHex $defaultCred.Key.Checksum }} {{ encodeHex $defaultCred.Cert.Checksum }}
-private-key-file={{ $defaultCred.Key.Path }}
-certificate-file={{ $defaultCred.Cert.Path }}
+private-key-file={{ .DefaultTLSCred.Key.Path }}
+certificate-file={{ .DefaultTLSCred.Cert.Path }}
 {{ range $cred := .SubTLSCred -}}
-# checksum: {{ encodeHex $cred.Key.Checksum }} {{ encodeHex $cred.Cert.Checksum }}
 subcert={{ $cred.Key.Path }}:{{ $cred.Cert.Path }}
 {{ end -}}
 {{ else if .HTTPSPort -}}

--- a/pkg/nghttpx/template_test.go
+++ b/pkg/nghttpx/template_test.go
@@ -167,8 +167,6 @@ frontend=127.0.0.1,0;api;no-tls
 # HTTPS port
 frontend=*,443
 # Default TLS credential
-# checksum is required to detect changes in the generated configuration and force a reload
-# checksum: 2c70e12b7a0646f92279f427c7b38e7334d8e5389cff167a1dc30e73f826b683 06298432e8066b29e2223bcc23aa9504b56ae508fabf3435508869b9c3190e22
 private-key-file=/tls/server.key
 certificate-file=/tls/server.crt
 # for health check
@@ -260,13 +258,9 @@ frontend=127.0.0.1,0;api;no-tls
 # HTTPS port
 frontend=*,443
 # Default TLS credential
-# checksum is required to detect changes in the generated configuration and force a reload
-# checksum: 2c70e12b7a0646f92279f427c7b38e7334d8e5389cff167a1dc30e73f826b683 06298432e8066b29e2223bcc23aa9504b56ae508fabf3435508869b9c3190e22
 private-key-file=/tls/server.key
 certificate-file=/tls/server.crt
-# checksum: b10253764c8b233fb37542e23401c7b450e5a6f9751f3b5a014f6f67e8bc999d cdf9e092139ce78806e2fbabc732bd2d322e964fa93a10a8e0155e673aa96737
 subcert=/tls/server2.key:/tls/server2.crt
-# checksum: f576104eebeab09651d83acffc77c8b8c6eaa4b767aeab24d7da80f83f51d865 9bffb43d004b76efd8c8bb6086d37b28737b85b455021ba0f20210062dda59ed
 subcert=/tls/server3.key:/tls/server3.crt
 # for health check
 frontend=127.0.0.1,0;healthmon;no-tls
@@ -506,8 +500,6 @@ altsvc=h3-29,443,,,ma=3600
 http2-altsvc=h3,443,,,ma=3600
 http2-altsvc=h3-29,443,,,ma=3600
 # Default TLS credential
-# checksum is required to detect changes in the generated configuration and force a reload
-# checksum: 2c70e12b7a0646f92279f427c7b38e7334d8e5389cff167a1dc30e73f826b683 06298432e8066b29e2223bcc23aa9504b56ae508fabf3435508869b9c3190e22
 private-key-file=/tls/server.key
 certificate-file=/tls/server.crt
 # for health check

--- a/pkg/nghttpx/types.go
+++ b/pkg/nghttpx/types.go
@@ -150,6 +150,7 @@ type Backend struct {
 // TLSCred stores TLS server private key, certificate file path, and optionally OCSP response.  OCSP response must be DER encoded byte
 // string.
 type TLSCred struct {
+	Name     string
 	Key      PrivateChecksumFile
 	Cert     ChecksumFile
 	OCSPResp *ChecksumFile


### PR DESCRIPTION
Use checksum as TLS key and certificate file name so that we can
remove checksum from the configuration file comment and only pass the
unique pairs of TLS private key, certificate, and optionally OCSP
response.