### PR TITLE
Downgrade libbpf to v1.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN git clone --depth 1 -b v0.13.1 https://github.com/ngtcp2/ngtcp2 && \
     cd .. && \
     rm -rf ngtcp2
 
-RUN git clone --depth 1 -b v1.1.0 https://github.com/libbpf/libbpf && \
+RUN git clone --depth 1 -b v1.0.1 https://github.com/libbpf/libbpf && \
     cd libbpf && \
     PREFIX=/usr/local make -C src install && \
     cd .. && \


### PR DESCRIPTION
Downgrade libbpf to v1.0.1 because it does not work with Ubuntu 20.04.