### PR TITLE
Share TLS ticket keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,17 @@ The key for OCSP response in TLS Secret is `tls.ocsp-resp` by default.
 It can be changed by `--ocsp-resp-key` flag.  The value of OCSP
 response in TLS Secret must be DER encoded.
 
+## Sharing TLS ticket keys
+
+By default, each nghttpx encrypts TLS ticket by its own key.  This
+means that if there are several nghttpx ingress controller instances,
+TLS session resumption might not work if the new connection goes to
+the different instance.  With `--share-tls-ticket-key` flag, the
+controller generates TLS ticket key in a Secret specified by
+`--nghttpx-secret`, which is shared by all controllers.  This ensures
+that all nghttpx instances use the same encryption key, which enables
+stable TLS session resumption.
+
 ## HTTP/3 (Experimental)
 
 In order to enable the experimental HTTP/3 feature, run the controller

--- a/cmd/nghttpx-ingress-controller/main.go
+++ b/cmd/nghttpx-ingress-controller/main.go
@@ -91,6 +91,7 @@ var (
 	internalDefaultBackend   = false
 	http3                    = false
 	nghttpxSecret            = "nghttpx-km"
+	shareTLSTicketKey        = false
 	reconcileTimeout         = 10 * time.Minute
 	leaderElectionConfig     = componentbaseconfig.LeaderElectionConfiguration{
 		LeaseDuration: metav1.Duration{Duration: 15 * time.Second},
@@ -190,6 +191,8 @@ func main() {
 	rootCmd.Flags().BoolVar(&http3, "http3", http3, `Enable HTTP/3.  This makes nghttpx listen to UDP port specified by nghttpx-https-port for HTTP/3 traffic.`)
 
 	rootCmd.Flags().StringVar(&nghttpxSecret, "nghttpx-secret", nghttpxSecret, `The name of Secret resource which contains the keying materials for nghttpx.  The resource must belong to the same namespace as the controller Pod.  If it is not found, the controller will create new one.`)
+
+	rootCmd.Flags().BoolVar(&shareTLSTicketKey, "share-tls-ticket-key", shareTLSTicketKey, `Share TLS ticket key among all nghttpx-ingress-controllers.  TLS ticket keys are stored to the Secret specified by nghttpx-secret flag.  If this flag is set to true, TLS ticket keys are generated and rotated by the controller every 1 hour.  At most 12 latest keys are retained.  TLS tickets are encrypted with AES-128-CBC.`)
 
 	rootCmd.Flags().DurationVar(&reconcileTimeout, "reconcile-timeout", reconcileTimeout,
 		`A timeout for a single reconciliation.  It is a safe guard to prevent a reconciliation from getting stuck indefinitely.`)
@@ -385,6 +388,7 @@ func run(ctx context.Context, _ *cobra.Command, _ []string) {
 		HealthzPort:                             healthzPort,
 		InternalDefaultBackend:                  internalDefaultBackend,
 		HTTP3:                                   http3,
+		ShareTLSTicketKey:                       shareTLSTicketKey,
 		ReconcileTimeout:                        reconcileTimeout,
 		LeaderElectionConfig:                    leaderElectionConfig,
 		RequireIngressClass:                     requireIngressClass,

--- a/pkg/nghttpx/command.go
+++ b/pkg/nghttpx/command.go
@@ -120,6 +120,9 @@ func (lb *LoadBalancer) CheckAndReload(ctx context.Context, ingressCfg *IngressC
 		if err := writePerPatternMrubyFile(ingressCfg); err != nil {
 			return false, err
 		}
+		if err := writeTLSTicketKeyFiles(ingressCfg); err != nil {
+			return false, err
+		}
 		if err := writeQUICSecretFile(ingressCfg); err != nil {
 			return false, err
 		}
@@ -172,7 +175,11 @@ func (lb *LoadBalancer) deleteStaleAssets(ctx context.Context, ingConfig *Ingres
 
 // deleteStaleTLSAssets deletes TLS asset files which are no longer used.
 func (lb *LoadBalancer) deleteStaleTLSAssets(ctx context.Context, ingConfig *IngressConfig, t time.Time) error {
-	return deleteAssetFiles(ctx, filepath.Join(ingConfig.ConfDir, tlsDir), t, lb.staleAssetsThreshold)
+	if err := deleteAssetFiles(ctx, filepath.Join(ingConfig.ConfDir, tlsDir), t, lb.staleAssetsThreshold); err != nil {
+		return err
+	}
+
+	return deleteAssetFiles(ctx, filepath.Join(ingConfig.ConfDir, tlsTicketKeyDir), t, lb.staleAssetsThreshold)
 }
 
 // deleteStaleMrubyAssets deletes mruby asset files which are no longer used.

--- a/pkg/nghttpx/nghttpx.tmpl
+++ b/pkg/nghttpx/nghttpx.tmpl
@@ -27,6 +27,9 @@ certificate-file={{ .DefaultTLSCred.Cert.Path }}
 {{ range $cred := .SubTLSCred -}}
 subcert={{ $cred.Key.Path }}:{{ $cred.Cert.Path }}
 {{ end -}}
+{{ range $ticketKey := .TLSTicketKeyFiles -}}
+tls-ticket-key-file={{ $ticketKey.Path }}
+{{ end -}}
 {{ else if .HTTPSPort -}}
 # just listen {{ .HTTPSPort }} to gain port {{ .HTTPSPort }}, so that we can always bind that address.
 frontend=*,{{ .HTTPSPort }};no-tls{{ if .ProxyProto }};proxyproto{{ end }}
@@ -51,4 +54,8 @@ mruby-file={{ .MrubyFile.Path }}
 fetch-ocsp-response-file=/cat-ocsp-resp
 {{ else -}}
 fetch-ocsp-response-file=/fetch-ocsp-response
+{{ end -}}
+{{ if and .ShareTLSTicketKey .HTTPSPort .TLS -}}
+# TLS ticket key
+tls-ticket-key-cipher=aes-128-cbc
 {{ end -}}

--- a/pkg/nghttpx/types.go
+++ b/pkg/nghttpx/types.go
@@ -85,6 +85,10 @@ type IngressConfig struct {
 	HTTP3 bool
 	// QUICSecretFile is the file which contains QUIC keying materials.
 	QUICSecretFile *PrivateChecksumFile
+	// ShareTLSTicketKey, if true, shares TLS ticket key among ingress controllers via Secret.
+	ShareTLSTicketKey bool
+	// TLSTicketKeyFiles is the list of files that contain TLS ticket key.
+	TLSTicketKeyFiles []*PrivateChecksumFile
 }
 
 // Upstream describes an nghttpx upstream


### PR DESCRIPTION
Share TLS ticket keys among nghttpx-ingress-controllers via Secret, which enables stable TLS session resumption.