### PR TITLE
Revise QUIC keying materials in backward incompatible way

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -2068,7 +2068,10 @@ func TestSyncSecretQUIC(t *testing.T) {
 					},
 				},
 				Data: map[string][]byte{
-					nghttpxQUICKeyingMaterialsSecretKey: []byte(`c0112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233`),
+					nghttpxQUICKeyingMaterialsSecretKey: []byte("" +
+						"80112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233\n" +
+						"c0112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233",
+					),
 				},
 			},
 			wantKeepTimestamp: true,
@@ -2084,7 +2087,10 @@ func TestSyncSecretQUIC(t *testing.T) {
 					},
 				},
 				Data: map[string][]byte{
-					nghttpxQUICKeyingMaterialsSecretKey: []byte(`c0112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233`),
+					nghttpxQUICKeyingMaterialsSecretKey: []byte("" +
+						"80112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233\n" +
+						"c0112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233",
+					),
 				},
 			},
 		},
@@ -2146,13 +2152,18 @@ func TestSyncSecretQUIC(t *testing.T) {
 				}
 
 				km := updatedSecret.Data[nghttpxQUICKeyingMaterialsSecretKey]
+
 				if len(km) < nghttpx.QUICKeyingMaterialsEncodedSize ||
 					len(km) != len(km)/nghttpx.QUICKeyingMaterialsEncodedSize*nghttpx.QUICKeyingMaterialsEncodedSize+(len(km)/nghttpx.QUICKeyingMaterialsEncodedSize-1) {
-					t.Fatal("updatedSecret does not contain QUIC keying materials", len(km))
+					t.Fatalf("updatedSecret does not contain QUIC keying materials: length=%v", len(km))
+				}
+
+				if tt.secret != nil && bytes.Equal(km, tt.secret.Data[nghttpxQUICKeyingMaterialsSecretKey]) {
+					t.Fatalf("updatedSecret.Data[%q] must be updated", nghttpxQUICKeyingMaterialsSecretKey)
 				}
 
 				if err := nghttpx.VerifyQUICKeyingMaterials(km); err != nil {
-					t.Fatalf("verifyQUICKeyingMaterials(...): %v", err)
+					t.Fatalf("VerifyQUICKeyingMaterials(...): %v", err)
 				}
 			}
 		})

--- a/pkg/nghttpx/quic.go
+++ b/pkg/nghttpx/quic.go
@@ -4,10 +4,15 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"io"
+	"math/bits"
 	"path/filepath"
 	"strings"
+
+	"golang.org/x/crypto/hkdf"
 )
 
 const (
@@ -44,6 +49,7 @@ func writeQUICSecretFile(ingConfig *IngressConfig) error {
 // VerifyQUICKeyingMaterials verifies that km is a well formatted QUIC keying material.
 func VerifyQUICKeyingMaterials(km []byte) error {
 	sc := bufio.NewScanner(bytes.NewBuffer(km))
+	var idBits uint8
 
 	for sc.Scan() {
 		l := sc.Text()
@@ -55,34 +61,90 @@ func VerifyQUICKeyingMaterials(km []byte) error {
 			return fmt.Errorf("each line of QUIC keying materials must be %v bytes long: %v", QUICKeyingMaterialsEncodedSize, ln)
 		}
 
-		if _, err := hex.DecodeString(l); err != nil {
+		b, err := hex.DecodeString(l)
+		if err != nil {
 			return fmt.Errorf("unable to decode QUIC keying materials from hex string: %w", err)
 		}
+
+		id := b[0] >> 6
+		mask := uint8(1 << id)
+
+		if (idBits & mask) != 0 {
+			return fmt.Errorf("duplicate ID found: %#x", id)
+		}
+
+		idBits |= mask
 	}
 
 	if err := sc.Err(); err != nil {
 		return fmt.Errorf("unable to read QUIC keying materials: %w", err)
 	}
 
+	if n := bits.OnesCount8(idBits); n < 2 {
+		return fmt.Errorf("requires at least 2 keys: %v keys found", n)
+	}
+
 	return nil
 }
 
 // NewQUICKeyingMaterial returns new QUIC keying material.
-func NewQUICKeyingMaterial() []byte {
-	b := make([]byte, QUICKeyingMaterialsSize)
-	if _, err := rand.Read(b); err != nil {
-		panic(err)
+func NewQUICKeyingMaterial() ([]byte, error) {
+	const ikmLen = 8
+
+	ikmSalt := make([]byte, ikmLen+sha256.Size)
+	if _, err := rand.Read(ikmSalt); err != nil {
+		return nil, err
 	}
 
-	return b
+	ikm := ikmSalt[:ikmLen]
+	salt := ikmSalt[ikmLen:]
+
+	r := hkdf.New(sha256.New, ikm, salt, []byte("quic key"))
+
+	b := make([]byte, QUICKeyingMaterialsSize)
+	if _, err := io.ReadFull(r, b); err != nil {
+		return nil, err
+	}
+
+	return b, nil
 }
 
-// UpdateQUICKeyingMaterials updates the existing QUIC keying materials km.  km may be nil or empty.
-func UpdateQUICKeyingMaterials(km []byte) []byte {
-	return updateQUICKeyingMaterialsFunc(km, NewQUICKeyingMaterial)
+func NewInitialQUICKeyingMaterials() ([]byte, error) {
+	keys := make([]string, 2)
+
+	for i := range keys {
+		b, err := NewQUICKeyingMaterial()
+		if err != nil {
+			return nil, err
+		}
+
+		b[0] = (b[0] & 0x3f) | byte((i << 6))
+
+		keys[i] = hex.EncodeToString(b)
+	}
+
+	return []byte(strings.Join(keys, "\n")), nil
 }
 
-func updateQUICKeyingMaterialsFunc(km []byte, newKeyingMaterialFunc func() []byte) []byte {
+// UpdateQUICKeyingMaterials calls UpdateQUICKeyingMaterialsFunc with NewQUICKeyingMaterial.
+func UpdateQUICKeyingMaterials(km []byte) ([]byte, error) {
+	return UpdateQUICKeyingMaterialsFunc(km, NewQUICKeyingMaterial)
+}
+
+// UpdateQUICKeyingMaterialsFunc generates new keying material via newKeyingMaterialFunc, and rotates keying materials, then returns new
+// QUIC keying materials.  VerifyQUICKeyingMaterials should be called against km and ensure that it succeeds before calling this function.
+//
+// km must include at least 2 keying materials.  New keying material is placed to the last.  Because the first keying material is used for
+// encryption, new keying material is not used for encryption immediately.  It is started to be used for encryption after the next rotation
+// in order to ensure that all controllers see this keying material.  The first 2 bits identifies the key, therefore at most 4 keying
+// materials are retained.  The oldest keying materials are discarded if the number of keys exceeds such limit.
+//
+// The rotation works as follows:
+//
+// 1. Move the last keying material (which is the new keying material generated in the previous update) to the first.
+// 2. Discard oldest keying materials if the number of keys exceeds 3.
+// 3. Generate new keying material and place it to the last.
+func UpdateQUICKeyingMaterialsFunc(km []byte, newKeyingMaterialFunc func() ([]byte, error)) ([]byte, error) {
 	var keys []string
 
 	sc := bufio.NewScanner(bytes.NewBuffer(km))
@@ -94,37 +156,47 @@ func updateQUICKeyingMaterialsFunc(km []byte, newKeyingMaterialFunc func() []byt
 		}
 
 		if len(l) != QUICKeyingMaterialsEncodedSize {
-			panic(fmt.Sprintf("not %v bytes long", QUICKeyingMaterialsEncodedSize))
+			return nil, fmt.Errorf("not %v bytes long", QUICKeyingMaterialsEncodedSize)
 		}
 
 		if _, err := hex.DecodeString(l); err != nil {
-			panic(err)
+			return nil, err
 		}
 
 		keys = append(keys, l)
-
-		if len(keys) == 3 {
-			break
-		}
 	}
 
-	if len(keys) == 0 {
-		return []byte(hex.EncodeToString(newKeyingMaterialFunc()))
+	if len(keys) < 2 {
+		return nil, fmt.Errorf("requires at least 2 keys: %v keys found", len(keys))
 	}
 
-	p := keys[0]
-	b, err := hex.DecodeString(p[0:2])
+	// The last key is the new key generated in the last update.
+	lastKM := keys[len(keys)-1]
+	b, err := hex.DecodeString(lastKM[0:2])
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	nextID := (b[0] + 0x40) & 0xc0
 
-	k := newKeyingMaterialFunc()
-	k[0] = (k[0] & 0x3f) | nextID
+	newKM, err := newKeyingMaterialFunc()
+	if err != nil {
+		return nil, err
+	}
 
-	newKeys := []string{hex.EncodeToString(k)}
-	newKeys = append(newKeys, keys...)
+	newKM[0] = (newKM[0] & 0x3f) | nextID
 
-	return []byte(strings.Join(newKeys, "\n"))
+	var newKeysLen int
+	if len(keys) < 4 {
+		newKeysLen = len(keys) + 1
+	} else {
+		newKeysLen = 4
+	}
+
+	newKeys := make([]string, newKeysLen)
+	newKeys[0] = lastKM
+	copy(newKeys[1:], keys[:newKeysLen-2])
+	newKeys[newKeysLen-1] = hex.EncodeToString(newKM)
+
+	return []byte(strings.Join(newKeys, "\n")), nil
 }


### PR DESCRIPTION
Now new key is placed at the end of QUIC keying materials.  It is not used for encryption immediately, and starts encrypting data on the next rotation, as we did for TLS ticket key.  This is a backward incompatible change.  There is no migration from the previous release because HTTP/3 is experimental.