### PR TITLE
Workaround incompatibility between go1.21+ go line and setup-go

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5
       with:
-        go-version-file: go.mod
+        go-version: '1.22'
     - uses: golangci/golangci-lint-action@v4
       with:
         skip-pkg-cache: true


### PR DESCRIPTION
Now go line in go.mod requires patch version.  go line indicates the minimum go version that this module requires.  Meanwhile, previously we set go line without patch version.  go-version-file of setup-go looks go line and picks the latest go patch version.  But now it includes patch version, setup-go always picks the exact version that go line specifies, which is not what we want.  As a workaround, stop using go-version-file, and use go-version.