### PR TITLE
Fix docker lint warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 # For the full copyright and license information, please view the LICENSE
 # file that was distributed with this source code.
 
-FROM debian:12 as build
+FROM debian:12 AS build
 
 COPY --link patches/extra-mrbgem.patch /
 


### PR DESCRIPTION
The 'as' keyword should match the case of the 'from' keyword