### PR TITLE
Replace go-difflib with go-cmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,18 +733,7 @@ TBD
 
 Using the `--v` flag it is possible to increase the level of logging.
 In particular:
-- `--v=2` shows details using `diff` about the changes in the configuration in nghttpx
-
-```
-I0323 04:39:16.552830       8 utils.go:90] nghttpx configuration diff /etc/nghttpx/nghttpx.conf
---- current
-+++ new
-@@ -1,7 +1,41 @@
--# A very simple nghttpx configuration file that forces nghttpx to start.
-+accesslog-file=/dev/stdout
-+include=/etc/nghttpx/nghttpx-backend.conf
-```
-
+- `--v=2` shows the differences between the previous and the current nghttpx configuration.
 - `--v=3` shows details about the service, Ingress rule, endpoint changes and it dumps the nghttpx configuration in JSON format
 
 ## Limitations

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/zlabjp/nghttpx-ingress-lb
 go 1.24.0
 
 require (
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
+	github.com/google/go-cmp v0.7.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/crypto v0.38.0
@@ -33,7 +33,6 @@ require (
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/gnostic-models v0.6.9 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
@@ -43,6 +42,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.22.0 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect

--- a/pkg/nghttpx/utils.go
+++ b/pkg/nghttpx/utils.go
@@ -37,7 +37,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/pmezard/go-difflib/difflib"
+	"github.com/google/go-cmp/cmp"
 	"golang.org/x/crypto/hkdf"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
@@ -84,28 +84,10 @@ func needsReload(ctx context.Context, filename string, newCfg []byte) (bool, err
 	}
 
 	if log := log.V(2); log.Enabled() {
-		dData, err := diff(oldCfg, newCfg)
-		if err != nil {
-			log.Error(err, "Error while computing diff")
-			return true, nil
-		}
-
-		log.Info("nghttpx configuration diff", "path", filename, "diff", dData)
+		log.Info("nghttpx configuration diff", "path", filename, "diff", cmp.Diff(oldCfg, newCfg))
 	}
 
 	return true, nil
-}
-
-func diff(b1, b2 []byte) (string, error) {
-	d := difflib.UnifiedDiff{
-		A:        difflib.SplitLines(string(b1)),
-		B:        difflib.SplitLines(string(b2)),
-		FromFile: "current",
-		ToFile:   "new",
-		Context:  3,
-	}
-
-	return difflib.GetUnifiedDiffString(d)
 }
 
 // FixupBackendConfig validates config, and fixes the invalid values inside it.


### PR DESCRIPTION
Get rid of unmaintained go-difflib, and use go-cmp instead.  go-cmp is not a drop-in replacement because the output differs.  But the main goal here is to show the differences between the configurations, and it can be achieved with go-cmp as well.