### PR TITLE
Run the controller and nghttpx as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@
 # file that was distributed with this source code.
 FROM debian:13 AS build
 
+# Set to false to disable HTTP/3.
+ARG ENABLE_HTTP3=true
+
 COPY --link patches/extra-mrbgem.patch /
 
 RUN <<EOF
@@ -40,7 +43,7 @@ EOT
 apt-get update
 apt-get install -y --no-install-recommends \
     git clang-19 make binutils autoconf automake autotools-dev libtool pkg-config cmake cmake-data \
-    zlib1g-dev libev-dev libjemalloc-dev ruby-dev libc-ares-dev bison patch libbrotli-dev
+    zlib1g-dev libev-dev libjemalloc-dev ruby-dev libc-ares-dev bison patch libbrotli-dev libcap2-bin
 apt-get install -y --no-install-recommends -t trixie-backports libelf-dev
 
 # aws-lc
@@ -108,11 +111,20 @@ autoreconf -i
     LIBBROTLIDEC_LIBS="-l:libbrotlidec.a -l:libbrotlicommon.a" \
     PKG_CONFIG_PATH="/usr/local/lib64/pkgconfig"
 make -j$(nproc) install-strip
+
+SETCAP=cap_net_bind_service
+
+if [ "$ENABLE_HTTP3" = "true" ]; then
+    SETCAP="$SETCAP,cap_bpf,cap_perfmon,cap_sys_resource"
+fi
+
+setcap "$SETCAP=+ep" /usr/local/bin/nghttpx
+
 cd ..
 rm -rf nghttp2
 EOF
 
-FROM gcr.io/distroless/base-nossl-debian13:latest
+FROM gcr.io/distroless/base-nossl-debian13:nonroot
 
 COPY --from=build --link /usr/local/bin/nghttpx /usr/local/bin/
 COPY --from=build --link /usr/local/lib/nghttp2/reuseport_kern.o \

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ The official Docker images since v0.67.0 are available at
 The images for older releases can be found at [Docker
 Hub](https://hub.docker.com/r/zlabjp/nghttpx-ingress-controller/).
 
+Since v0.77.0, the processes inside the container run as non-root user
+(65532:65532 as per distroless nonroot image).  You might need some
+adjustments to your manifests.  Currently, ``allowPrivilegeEscalation:
+false`` does not work due to the limitation of Kubernetes and
+container runtime.
+
 ## Requirements
 
 If `--internal-default-backend` flag is given to false, the default
@@ -188,26 +194,17 @@ and new key is generated in the interval specified by
 > is first placed at the end of the list.  In the next rotation, it is
 > moved to the first, and is used for encryption.
 
-HTTP/3 requires the extra capabilities to load eBPF program.  Add the
-following capabilities to the nghttpx-ingress-controller container:
-
-```yaml
-apiVersion: apps/v1
-kind: DaemonSet
-...
-spec:
-  template:
-    spec:
-      containers:
-      - image: zlabjp/nghttpx-ingress-controller:latest
-        ...
-        securityContext:
-          capabilities:
-            add:
-            - SYS_ADMIN
-            - SYS_RESOURCE
-        ...
-```
+HTTP/3 requires the extra capabilities to load eBPF program, more
+specifically, ``BPF``, ``PERFMON``, and ``SYS_RESOURCE``.  Due to the
+constraints around the Linux capabilities in Kubernetes and the
+underlying container runtime when running Pod as non-root user, we use
+file capabilities to gain these capabilities and it is done in the
+image build time.  Because the container image we publish enables
+HTTP/3, this image requires these capabilities.  Our example manifests
+include them.  If you need to drop these capabilities to adhere Pod
+Security Standards baseline profile, build the image with
+``--build-arg ENABLE_HTTP3=false``.  Then only capability you need is
+``NET_BIND_SERVICE``.
 
 ## Gateway API support (Experimental)
 

--- a/examples/custom-configuration/rc-custom-configuration.yaml
+++ b/examples/custom-configuration/rc-custom-configuration.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 60
       hostNetwork: true
       containers:
-      - image: zlabjp/nghttpx-ingress-controller:latest
+      - image: ghcr.io/zlabjp/nghttpx-ingress-controller:latest
         name: nghttpx-ingress-lb
         imagePullPolicy: Always
         startupProbe:
@@ -63,3 +63,24 @@ spec:
         - /nghttpx-ingress-controller
         - --nghttpx-configmap=default/nghttpx-ingress-lb
         - --healthz-port=11249
+        securityContext:
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            # The following capabilities are required to load eBPF
+            # program that is used by HTTP/3.  They can be omitted if
+            # the container image is built without HTTP/3 support, by
+            # using --build-arg ENABLE_HTTP3=false.
+            - BPF
+            - PERFMON
+            - SYS_RESOURCE
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        volumeMounts:
+        - mountPath: /etc/nghttpx
+          name: conf
+      volumes:
+      - emptyDir: {}
+        name: conf

--- a/examples/daemonset/as-daemonset.yaml
+++ b/examples/daemonset/as-daemonset.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 60
       hostNetwork: true
       containers:
-      - image: zlabjp/nghttpx-ingress-controller:latest
+      - image: ghcr.io/zlabjp/nghttpx-ingress-controller:latest
         name: nghttpx-ingress-lb
         imagePullPolicy: Always
         startupProbe:
@@ -62,3 +62,24 @@ spec:
         args:
         - /nghttpx-ingress-controller
         - --healthz-port=11249
+        securityContext:
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            # The following capabilities are required to load eBPF
+            # program that is used by HTTP/3.  They can be omitted if
+            # the container image is built without HTTP/3 support, by
+            # using --build-arg ENABLE_HTTP3=false.
+            - BPF
+            - PERFMON
+            - SYS_RESOURCE
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        volumeMounts:
+        - mountPath: /etc/nghttpx
+          name: conf
+      volumes:
+      - emptyDir: {}
+        name: conf

--- a/examples/default/rc-default.yaml
+++ b/examples/default/rc-default.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 60
       hostNetwork: true
       containers:
-      - image: zlabjp/nghttpx-ingress-controller:latest
+      - image: ghcr.io/zlabjp/nghttpx-ingress-controller:latest
         name: nghttpx-ingress-lb
         imagePullPolicy: Always
         startupProbe:
@@ -62,3 +62,24 @@ spec:
         args:
         - /nghttpx-ingress-controller
         - --healthz-port=11249
+        securityContext:
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            # The following capabilities are required to load eBPF
+            # program that is used by HTTP/3.  They can be omitted if
+            # the container image is built without HTTP/3 support, by
+            # using --build-arg ENABLE_HTTP3=false.
+            - BPF
+            - PERFMON
+            - SYS_RESOURCE
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        volumeMounts:
+        - mountPath: /etc/nghttpx
+          name: conf
+      volumes:
+      - emptyDir: {}
+        name: conf

--- a/examples/proxyproto/02-nghttpx.yaml
+++ b/examples/proxyproto/02-nghttpx.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 60
       hostNetwork: true # disable this if you do not need CNI
       containers:
-      - image: zlabjp/nghttpx-ingress-controller:latest
+      - image: ghcr.io/zlabjp/nghttpx-ingress-controller:latest
         name: nghttpx-ingress-lb
         imagePullPolicy: Always
         startupProbe:
@@ -76,3 +76,24 @@ spec:
         - --nghttpx-configmap=$(POD_NAMESPACE)/nghttpx-ingress-lb-config
         - --healthz-port=11249
         - --proxy-proto=true
+        securityContext:
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            # The following capabilities are required to load eBPF
+            # program that is used by HTTP/3.  They can be omitted if
+            # the container image is built without HTTP/3 support, by
+            # using --build-arg ENABLE_HTTP3=false.
+            - BPF
+            - PERFMON
+            - SYS_RESOURCE
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        volumeMounts:
+        - mountPath: /etc/nghttpx
+          name: conf
+      volumes:
+      - emptyDir: {}
+        name: conf

--- a/rc.yaml
+++ b/rc.yaml
@@ -91,7 +91,7 @@ spec:
       terminationGracePeriodSeconds: 60
       hostNetwork: true
       containers:
-      - image: zlabjp/nghttpx-ingress-controller:latest
+      - image: ghcr.io/zlabjp/nghttpx-ingress-controller:latest
         name: nghttpx-ingress-lb
         startupProbe:
           httpGet:
@@ -134,9 +134,23 @@ spec:
         - /nghttpx-ingress-controller
         - --healthz-port=11249
         securityContext:
-          # These capabilities are required to load eBPF program which is used by HTTP/3.
-          # They can be removed if HTTP/3 is not used.
           capabilities:
             add:
-            - SYS_ADMIN
+            - NET_BIND_SERVICE
+            # The following capabilities are required to load eBPF
+            # program that is used by HTTP/3.  They can be omitted if
+            # the container image is built without HTTP/3 support, by
+            # using --build-arg ENABLE_HTTP3=false.
+            - BPF
+            - PERFMON
             - SYS_RESOURCE
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        volumeMounts:
+        - mountPath: /etc/nghttpx
+          name: conf
+      volumes:
+      - emptyDir: {}
+        name: conf


### PR DESCRIPTION
The default published image enables HTTP/3 that requires the following extra capabilities:

- BPF
- PERFMON
- SYS_RESOURCE

If you need to drop these capabilities, rebuild the image with --build-arg ENABLE_HTTP3=false.

Currently, allowPrevilegeEscalation: false does not work due to the limitation of Kubernetes and the underlying container runtime.